### PR TITLE
Detector will always write PACK_DETECT_INFO_PATH

### DIFF
--- a/cmd/detector/main.go
+++ b/cmd/detector/main.go
@@ -72,10 +72,8 @@ func detect() error {
 		return packs.FailErr(err, "write buildpack group")
 	}
 
-	if len(info) > 0 {
-		if err := ioutil.WriteFile(infoPath, info, 0666); err != nil {
-			return packs.FailErr(err, "write detect info")
-		}
+	if err := ioutil.WriteFile(infoPath, info, 0666); err != nil {
+		return packs.FailErr(err, "write detect info")
 	}
 
 	return nil


### PR DESCRIPTION
Builder expects PACK_DETECT_INFO_PATH (detect.toml) to always exist, and
and empty file is ok.