### PR TITLE
Refactor order.toml to have buildpacks as struct

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/BurntSushi/toml"
 	"github.com/buildpack/packs"
@@ -13,7 +12,7 @@ import (
 )
 
 type Analyzer struct {
-	Buildpacks []string
+	Buildpacks []*Buildpack
 	In         []byte
 	Out, Err   io.Writer
 }
@@ -60,9 +59,8 @@ func (a *Analyzer) getBuildMetadata(image v1.Image) (packs.BuildMetadata, error)
 
 func (a *Analyzer) buildpacks() map[string]struct{} {
 	buildpacks := make(map[string]struct{}, len(a.Buildpacks))
-	for _, buildpack := range a.Buildpacks {
-		a := strings.SplitN(buildpack, "@", 2)
-		buildpacks[a[0]] = struct{}{}
+	for _, b := range a.Buildpacks {
+		buildpacks[b.ID] = struct{}{}
 	}
 	return buildpacks
 }

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -44,7 +44,7 @@ func testAnalyzer(t *testing.T, when spec.G, it spec.S) {
 
 		stdout, stderr = &bytes.Buffer{}, &bytes.Buffer{}
 		analyzer = &lifecycle.Analyzer{
-			Buildpacks: []string{"buildpack.node@1.0.0", "buildpack.go"},
+			Buildpacks: []*lifecycle.Buildpack{{ID: "buildpack.node"}, {ID: "buildpack.go"}},
 			Out:        io.MultiWriter(stdout, it.Out()),
 			Err:        io.MultiWriter(stderr, it.Out()),
 		}
@@ -144,7 +144,7 @@ func testAnalyzer(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("only writes layer toml files that correspond to detected buildpacks", func() {
-				analyzer.Buildpacks = []string{"buildpack.go"}
+				analyzer.Buildpacks = []*lifecycle.Buildpack{{ID: "buildpack.go"}}
 
 				if err := analyzer.Analyze(launchDir, image); err != nil {
 					t.Fatalf("Error: %s\n", err)

--- a/cmd/analyzer/main.go
+++ b/cmd/analyzer/main.go
@@ -42,9 +42,7 @@ func analyzer() error {
 		}
 	}
 
-	var group struct {
-		Buildpacks []string
-	}
+	var group lifecycle.BuildpackGroup
 	if _, err := toml.DecodeFile(groupPath, &group); err != nil {
 		return packs.FailErr(err, "read group")
 	}

--- a/cmd/builder/main.go
+++ b/cmd/builder/main.go
@@ -4,9 +4,7 @@ import (
 	"flag"
 	"io/ioutil"
 	"os"
-	"path"
 
-	"github.com/BurntSushi/toml"
 	"github.com/buildpack/packs"
 
 	"github.com/buildpack/lifecycle"
@@ -40,19 +38,19 @@ func build() error {
 	if err != nil {
 		return packs.FailErr(err, "read buildpack directory")
 	}
-	var group struct {
-		Buildpacks []string
-	}
-	if _, err := toml.DecodeFile(groupPath, &group); err != nil {
+	group, err := buildpacks.ReadGroup(groupPath)
+	if err != nil {
 		return packs.FailErr(err, "read group")
 	}
+
 	info, err := ioutil.ReadFile(infoPath)
 	if err != nil {
 		return packs.FailErr(err, "read detect info")
 	}
+
 	builder := &lifecycle.Builder{
 		PlatformDir: lifecycle.DefaultPlatformDir,
-		Buildpacks:  buildpacks.FromList(group.Buildpacks),
+		Buildpacks:  group.Buildpacks,
 		In:          info,
 		Out:         os.Stdout,
 		Err:         os.Stderr,
@@ -72,15 +70,8 @@ func build() error {
 	if err != nil {
 		return packs.FailErrCode(err, packs.CodeFailedBuild)
 	}
-	if err := os.MkdirAll(path.Dir(metadataPath), 0750); err != nil {
-		return packs.FailErr(err, "create metadata dir")
-	}
-	mdFile, err := os.Create(metadataPath)
-	if err != nil {
-		return packs.FailErr(err, "create metadata file")
-	}
-	defer mdFile.Close()
-	if err := toml.NewEncoder(mdFile).Encode(metadata); err != nil {
+
+	if err := lifecycle.WriteTOML(metadataPath, metadata); err != nil {
 		return packs.FailErr(err, "write metadata")
 	}
 	return nil

--- a/cmd/detector/main.go
+++ b/cmd/detector/main.go
@@ -2,13 +2,10 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
-	"strings"
 
-	"github.com/BurntSushi/toml"
 	"github.com/buildpack/packs"
 
 	"github.com/buildpack/lifecycle"
@@ -19,8 +16,6 @@ var (
 	orderPath     string
 	groupPath     string
 	infoPath      string
-
-	buildpacks lifecycle.BuildpackMap
 )
 
 func init() {
@@ -40,35 +35,23 @@ func main() {
 }
 
 func detect() error {
-	var err error
-	buildpacks, err = lifecycle.NewBuildpackMap(buildpackPath)
+	log := log.New(os.Stderr, "", log.LstdFlags)
+
+	buildpacks, err := lifecycle.NewBuildpackMap(buildpackPath)
 	if err != nil {
 		return packs.FailErr(err, "read buildpack directory")
 	}
-
-	var order buildpackRefOrder
-	if _, err := toml.DecodeFile(orderPath, &order); err != nil {
-		return packs.FailErr(err, "read buildpack order")
+	order, err := buildpacks.ReadOrder(orderPath)
+	if err != nil {
+		return packs.FailErr(err, "read buildpack order file")
 	}
 
-	log := log.New(os.Stderr, "", log.LstdFlags)
-	info, group := order.order().Detect(log, lifecycle.DefaultAppDir)
+	info, group := order.Detect(log, lifecycle.DefaultAppDir)
 	if len(group.Buildpacks) == 0 {
 		return packs.FailCode(packs.CodeFailedDetect, "detect")
 	}
 
-	groupFile, err := os.Create(groupPath)
-	if err != nil {
-		return packs.FailErr(err, "create buildpack group file")
-	}
-	defer groupFile.Close()
-	if err := toml.NewEncoder(groupFile).Encode(struct {
-		Buildpacks []string `toml:"buildpacks"`
-		Repository string   `toml:"repository"`
-	}{
-		Buildpacks: group.List(),
-		Repository: group.Repository,
-	}); err != nil {
+	if err := group.Write(groupPath); err != nil {
 		return packs.FailErr(err, "write buildpack group")
 	}
 
@@ -77,46 +60,4 @@ func detect() error {
 	}
 
 	return nil
-}
-
-type buildpackRef struct {
-	*lifecycle.Buildpack
-}
-
-func (bp *buildpackRef) UnmarshalText(b []byte) error {
-	ref := string(b)
-	if !strings.Contains(ref, "@") {
-		ref += "@latest"
-	}
-	var ok bool
-	if bp.Buildpack, ok = buildpacks[ref]; !ok {
-		return fmt.Errorf("invalid buildpack reference: %s", ref)
-	}
-	return nil
-}
-
-type buildpackRefGroup struct {
-	Buildpacks []buildpackRef `toml:"buildpacks"`
-	Repository string         `toml:"repository"`
-}
-
-func (bg buildpackRefGroup) group() lifecycle.BuildpackGroup {
-	var group lifecycle.BuildpackGroup
-	for _, bp := range bg.Buildpacks {
-		group.Buildpacks = append(group.Buildpacks, bp.Buildpack)
-	}
-	group.Repository = bg.Repository
-	return group
-}
-
-type buildpackRefOrder struct {
-	Groups []buildpackRefGroup `toml:"groups"`
-}
-
-func (bo buildpackRefOrder) order() lifecycle.BuildpackOrder {
-	var order lifecycle.BuildpackOrder
-	for _, g := range bo.Groups {
-		order = append(order, g.group())
-	}
-	return order
 }

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strings"
 
 	"github.com/BurntSushi/toml"
 	"github.com/buildpack/lifecycle"
@@ -77,9 +76,7 @@ func export() error {
 		origImage = nil
 	}
 
-	var group struct {
-		Buildpacks []string
-	}
+	var group lifecycle.BuildpackGroup
 	if _, err := toml.DecodeFile(groupPath, &group); err != nil {
 		return packs.FailErr(err, "read group")
 	}
@@ -91,7 +88,7 @@ func export() error {
 	defer os.RemoveAll(tmpDir)
 
 	exporter := &lifecycle.Exporter{
-		Buildpacks: buildpacksFromList(group.Buildpacks),
+		Buildpacks: group.Buildpacks,
 		TmpDir:     tmpDir,
 		Out:        os.Stdout,
 		Err:        os.Stderr,
@@ -110,13 +107,4 @@ func export() error {
 	}
 
 	return nil
-}
-
-func buildpacksFromList(input []string) []lifecycle.Buildpack {
-	buildpacks := make([]lifecycle.Buildpack, 0, len(input))
-	for _, s := range input {
-		m := strings.SplitN(s, "@", 2)
-		buildpacks = append(buildpacks, lifecycle.Buildpack{ID: m[0]})
-	}
-	return buildpacks
 }

--- a/detector.go
+++ b/detector.go
@@ -20,11 +20,16 @@ const (
 	CodeDetectFail = 100
 )
 
+type SimpleBuildpack struct {
+	ID      string `toml:"id"`
+	Version string `toml:"version"`
+}
+
 type Buildpack struct {
-	ID      string
-	Name    string
-	Version string
-	Dir     string
+	ID      string `toml:"id"`
+	Version string `toml:"version"`
+	Name    string `toml:"name"`
+	Dir     string `toml:"-"`
 }
 
 func (bp *Buildpack) Detect(l *log.Logger, appDir string, in io.Reader, out io.Writer) int {
@@ -57,8 +62,8 @@ func (bp *Buildpack) Detect(l *log.Logger, appDir string, in io.Reader, out io.W
 }
 
 type BuildpackGroup struct {
-	Buildpacks []*Buildpack
-	Repository string
+	Buildpacks []*Buildpack `toml:"buildpacks"`
+	Repository string       `toml:"repository"`
 }
 
 func (bg *BuildpackGroup) Detect(l *log.Logger, appDir string) (info []byte, ok bool) {
@@ -119,14 +124,6 @@ func (bg *BuildpackGroup) pDetect(l *log.Logger, appDir string) (info []byte, co
 		}
 	}
 	return info, codes
-}
-
-func (bg *BuildpackGroup) List() []string {
-	var out []string
-	for _, bp := range bg.Buildpacks {
-		out = append(out, bp.ID+"@"+bp.Version)
-	}
-	return out
 }
 
 func mergeTOML(l *log.Logger, out io.Writer, in ...io.Reader) {

--- a/detector_test.go
+++ b/detector_test.go
@@ -19,7 +19,6 @@ import (
 
 func TestDetector(t *testing.T) {
 	spec.Run(t, "Detector", testDetector, spec.Report(report.Terminal{}))
-	spec.Run(t, "Group", testGroup, spec.Report(report.Terminal{}))
 }
 
 func testDetector(t *testing.T, when spec.G, it spec.S) {
@@ -122,27 +121,6 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 				"2 = true\nGroup: buildpack1-name: error (1) | buildpack2-name: error (1)\n",
 			) {
 				t.Fatalf("Unexpected log: %s\n", out)
-			}
-		})
-	})
-}
-
-func testGroup(t *testing.T, when spec.G, it spec.S) {
-	when("#List", func() {
-		it("should return a list of references to buildpacks", func() {
-			group := lifecycle.BuildpackGroup{
-				Buildpacks: []*lifecycle.Buildpack{
-					{ID: "buildpack1-id", Version: "0.0.1"},
-					{ID: "buildpack2-id", Version: "0.0.2"},
-					{ID: "buildpack3-id", Version: "0.0.3"},
-				},
-			}
-			if l := group.List(); !reflect.DeepEqual(l, []string{
-				"buildpack1-id@0.0.1",
-				"buildpack2-id@0.0.2",
-				"buildpack3-id@0.0.3",
-			}) {
-				t.Fatalf("Unexpected reference list: %#v\n", l)
 			}
 		})
 	})

--- a/exporter.go
+++ b/exporter.go
@@ -19,7 +19,7 @@ import (
 )
 
 type Exporter struct {
-	Buildpacks []Buildpack
+	Buildpacks []*Buildpack
 	TmpDir     string
 	In         []byte
 	Out, Err   io.Writer

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -43,7 +43,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 		}
 		exporter = &lifecycle.Exporter{
 			TmpDir: tmpDir,
-			Buildpacks: []lifecycle.Buildpack{
+			Buildpacks: []*lifecycle.Buildpack{
 				{ID: "buildpack.id"},
 			},
 			Out: io.MultiWriter(stdout, it.Out()),

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,20 @@
+package lifecycle
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+)
+
+func WriteTOML(path string, data interface{}) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
+		return err
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return toml.NewEncoder(f).Encode(data)
+}


### PR DESCRIPTION
Previously
```
repository = "packs/v3"
buildpacks = ["sh.packs.samples.buildpack.nodejs@0.0.1"]
```

Now
```
repository = "packs/v3"

[[buildpacks]]
  id = "sh.packs.samples.buildpack.nodejs"
  version = "0.0.1"
```

Signed-off-by: Anthony Emengo <aemengo@pivotal.io>
Signed-off-by: Dave Goddard <dave@goddard.id.au>