### PR TITLE
Split Repository into build and run images

### DIFF
--- a/detector.go
+++ b/detector.go
@@ -59,12 +59,14 @@ func (bp *Buildpack) Detect(l *log.Logger, appDir string, in io.Reader, out io.W
 
 type BuildpackGroup struct {
 	Buildpacks []*Buildpack `toml:"buildpacks"`
-	Repository string       `toml:"repository"`
+	BuildImage string       `toml:"build-image"`
+	RunImage   string       `toml:"run-image"`
 }
 
 func (bg *BuildpackGroup) Detect(l *log.Logger, appDir string) (info []byte, group *BuildpackGroup, ok bool) {
 	group = &BuildpackGroup{
-		Repository: bg.Repository,
+		BuildImage: bg.BuildImage,
+		RunImage:   bg.RunImage,
 	}
 	detected := true
 	summary := "Group:"

--- a/detector_test.go
+++ b/detector_test.go
@@ -42,7 +42,8 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					{Name: "buildpack3-name", Dir: buildpackDir},
 					{Name: "buildpack4-name", Dir: buildpackDir},
 				},
-				Repository: "repository1",
+				BuildImage: "build-image-1",
+				RunImage:   "run-image-1",
 			},
 			{
 				Buildpacks: []*lifecycle.Buildpack{
@@ -51,7 +52,8 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					{Name: "buildpack3-name", Dir: buildpackDir},
 					{Name: "buildpack4-name", Dir: buildpackDir, Optional: true},
 				},
-				Repository: "repository2",
+				BuildImage: "build-image-2",
+				RunImage:   "run-image-2",
 			},
 			{
 				Buildpacks: []*lifecycle.Buildpack{
@@ -59,14 +61,16 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					{Name: "buildpack2-name", Dir: buildpackDir},
 					{Name: "buildpack3-name", Dir: buildpackDir},
 				},
-				Repository: "repository3",
+				BuildImage: "build-image-3",
+				RunImage:   "run-image-3",
 			},
 			{
 				Buildpacks: []*lifecycle.Buildpack{
 					{Name: "buildpack1-name", Dir: buildpackDir},
 					{Name: "buildpack2-name", Dir: buildpackDir},
 				},
-				Repository: "repository4",
+				BuildImage: "build-image-4",
+				RunImage:   "run-image-4",
 			},
 		}
 	})

--- a/map.go
+++ b/map.go
@@ -67,7 +67,8 @@ func (m BuildpackMap) ReadOrder(orderPath string) (BuildpackOrder, error) {
 	var groups BuildpackOrder
 	for _, g := range order.Groups {
 		groups = append(groups, BuildpackGroup{
-			Repository: g.Repository,
+			BuildImage: g.BuildImage,
+			RunImage:   g.RunImage,
 			Buildpacks: m.lookup(g.Buildpacks),
 		})
 	}
@@ -76,10 +77,12 @@ func (m BuildpackMap) ReadOrder(orderPath string) (BuildpackOrder, error) {
 
 func (g *BuildpackGroup) Write(path string) error {
 	data := struct {
-		Repository string       `toml:"repository"`
+		BuildImage string       `toml:"build-image"`
+		RunImage   string       `toml:"run-image"`
 		Buildpacks []*Buildpack `toml:"buildpacks"`
 	}{
-		Repository: g.Repository,
+		BuildImage: g.BuildImage,
+		RunImage:   g.RunImage,
 		Buildpacks: g.Buildpacks,
 	}
 	return WriteTOML(path, data)

--- a/map_test.go
+++ b/map_test.go
@@ -89,7 +89,7 @@ func testMap(t *testing.T, when spec.G, it spec.S) {
 				"buildpack1@version1.2": {Name: "buildpack1-1.2"},
 				"buildpack2@latest":     {Name: "buildpack2"},
 			}
-			mkfile(t, `groups = [{ repository = "local", buildpacks = [{id = "buildpack1", version = "version1.1"}, {id = "buildpack2", optional = true}] }]`,
+			mkfile(t, `groups = [{ build-image = "local-build", run-image = "local-run", buildpacks = [{id = "buildpack1", version = "version1.1"}, {id = "buildpack2", optional = true}] }]`,
 				filepath.Join(tmpDir, "order.toml"),
 			)
 			actual, err := m.ReadOrder(filepath.Join(tmpDir, "order.toml"))
@@ -97,7 +97,7 @@ func testMap(t *testing.T, when spec.G, it spec.S) {
 				t.Fatal(err)
 			}
 			if !reflect.DeepEqual(actual, lifecycle.BuildpackOrder{
-				{Repository: "local", Buildpacks: []*lifecycle.Buildpack{
+				{BuildImage: "local-build", RunImage: "local-run", Buildpacks: []*lifecycle.Buildpack{
 					{Name: "buildpack1-1.1"},
 					{Name: "buildpack2", Optional: true},
 				}},
@@ -128,7 +128,7 @@ func testMap(t *testing.T, when spec.G, it spec.S) {
 				"buildpack1@version1.2": {Name: "buildpack1-1.2"},
 				"buildpack2@latest":     {Name: "buildpack2"},
 			}
-			mkfile(t, `repository = "myrepo"`+"\n"+
+			mkfile(t, `build-image = "myrepo"`+"\n"+`run-image = "myrepo"`+"\n"+
 				`buildpacks = [{id = "buildpack1", version = "version1.1"}, {id = "buildpack2", optional = true}]`,
 				filepath.Join(tmpDir, "group.toml"),
 			)
@@ -137,7 +137,8 @@ func testMap(t *testing.T, when spec.G, it spec.S) {
 				t.Fatal(err)
 			}
 			if !reflect.DeepEqual(actual, &lifecycle.BuildpackGroup{
-				Repository: "myrepo",
+				BuildImage: "myrepo",
+				RunImage:   "myrepo",
 				Buildpacks: []*lifecycle.Buildpack{{Name: "buildpack1-1.1"}, {Name: "buildpack2", Optional: true}},
 			}) {
 				t.Fatalf("Unexpected list: %#v\n", actual)
@@ -162,7 +163,8 @@ func testMap(t *testing.T, when spec.G, it spec.S) {
 
 		it("should write only ID and version", func() {
 			group := lifecycle.BuildpackGroup{
-				Repository: "myrepo",
+				BuildImage: "myrepo1",
+				RunImage:   "myrepo2",
 				Buildpacks: []*lifecycle.Buildpack{{ID: "a", Name: "b", Version: "v", Dir: "d"}},
 			}
 			if err := group.Write(filepath.Join(tmpDir, "group.toml")); err != nil {
@@ -172,7 +174,8 @@ func testMap(t *testing.T, when spec.G, it spec.S) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(string(b), `repository = "myrepo"
+			if diff := cmp.Diff(string(b), `build-image = "myrepo1"
+run-image = "myrepo2"
 
 [[buildpacks]]
   id = "a"


### PR DESCRIPTION
This means we no longer infer :build and :run tags from the repository base

See: https://github.com/buildpack/pack/issues/17