### PR TITLE
Accept metadata json as cli arg

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -1,13 +1,15 @@
 package lifecycle
 
 import (
-	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/BurntSushi/toml"
-	"github.com/google/go-containerregistry/pkg/v1"
+	"github.com/buildpack/lifecycle/cmd"
+	"github.com/buildpack/lifecycle/img"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
 type Analyzer struct {
@@ -16,27 +18,7 @@ type Analyzer struct {
 	Out, Err   io.Writer
 }
 
-func (a *Analyzer) Analyze(launchDir, configJSON string, image v1.Image) error {
-	if configJSON == "" {
-		var err error
-		configJSON, err = a.getMetadata(image)
-		if err != nil {
-			return err
-		}
-	}
-	if configJSON == "" {
-		return nil
-	}
-
-	config := AppImageMetadata{}
-	if err := json.Unmarshal([]byte(configJSON), &config); err != nil {
-		return err
-	}
-
-	return a.AnalyzeConfig(launchDir, config)
-}
-
-func (a *Analyzer) AnalyzeConfig(launchDir string, config AppImageMetadata) error {
+func (a *Analyzer) Analyze(launchDir string, config AppImageMetadata) error {
 	buildpacks := a.buildpacks()
 	for _, buildpack := range config.Buildpacks {
 		if _, exist := buildpacks[buildpack.ID]; !exist {
@@ -53,12 +35,37 @@ func (a *Analyzer) AnalyzeConfig(launchDir string, config AppImageMetadata) erro
 	return nil
 }
 
-func (a *Analyzer) getMetadata(image v1.Image) (string, error) {
-	configFile, err := image.ConfigFile()
+func (a *Analyzer) GetMetadata(newRepoStore func(string) (img.Store, error), repoName string) (string, error) {
+	repoStore, err := newRepoStore(repoName)
 	if err != nil {
-		return "", err
+		return "", cmd.FailErr(err, "repository configuration", repoName)
 	}
-	return configFile.Config.Labels[MetadataLabel], nil
+
+	origImage, err := repoStore.Image()
+	if err != nil {
+		fmt.Fprintf(a.Out, "WARNING: skipping analyze, authenticating to registry failed: %s", err.Error())
+		return "", nil
+	}
+	if _, err := origImage.RawManifest(); err != nil {
+		if remoteErr, ok := err.(*remote.Error); ok && len(remoteErr.Errors) > 0 {
+			switch remoteErr.Errors[0].Code {
+			case remote.UnauthorizedErrorCode, remote.ManifestUnknownErrorCode:
+				fmt.Fprintf(a.Out, "WARNING: skipping analyze, image not found or requires authentication to access: %s", remoteErr.Error())
+				return "", nil
+			}
+		}
+		return "", cmd.FailErr(err, "access manifest", repoName)
+	}
+
+	configFile, err := origImage.ConfigFile()
+	if err != nil {
+		return "", cmd.FailErr(err, "image configfile", repoName)
+	}
+	label := configFile.Config.Labels[MetadataLabel]
+	if label == "" {
+		fmt.Fprintf(a.Out, "WARNING: skipping analyze, previous image metadata was not found")
+	}
+	return label, nil
 }
 
 func (a *Analyzer) buildpacks() map[string]struct{} {

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -2,16 +2,21 @@ package lifecycle_test
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/buildpack/lifecycle"
+	"github.com/buildpack/lifecycle/img"
 	"github.com/buildpack/lifecycle/testmock"
 	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 )
@@ -21,20 +26,18 @@ func TestAnalyzer(t *testing.T) {
 }
 
 //go:generate mockgen -package testmock -destination testmock/image.go github.com/google/go-containerregistry/pkg/v1 Image
+//go:generate mockgen -package testmock -destination testmock/store.go github.com/buildpack/lifecycle/img Store
 
 func testAnalyzer(t *testing.T, when spec.G, it spec.S) {
 	var (
-		analyzer       *lifecycle.Analyzer
-		mockCtrl       *gomock.Controller
-		stdout, stderr *bytes.Buffer
-		launchDir      string
-		image          *testmock.MockImage
+		analyzer         *lifecycle.Analyzer
+		mockCtrl         *gomock.Controller
+		stdout, stderr   *bytes.Buffer
+		launchDir        string
+		appImageMetadata lifecycle.AppImageMetadata
 	)
 
 	it.Before(func() {
-		mockCtrl = gomock.NewController(t)
-		image = testmock.NewMockImage(mockCtrl)
-
 		var err error
 		launchDir, err = ioutil.TempDir("", "lifecycle-launch-dir")
 		if err != nil {
@@ -47,6 +50,7 @@ func testAnalyzer(t *testing.T, when spec.G, it spec.S) {
 			Out:        io.MultiWriter(stdout, it.Out()),
 			Err:        io.MultiWriter(stderr, it.Out()),
 		}
+		mockCtrl = gomock.NewController(t)
 	})
 
 	it.After(func() {
@@ -57,35 +61,33 @@ func testAnalyzer(t *testing.T, when spec.G, it spec.S) {
 	when("#Analyze", func() {
 		when("image exists and has labels", func() {
 			it.Before(func() {
-				var configFile = &v1.ConfigFile{}
-				configFile.Config.Labels = map[string]string{lifecycle.MetadataLabel: `{
-					"buildpacks": [
-						{
-							"key": "buildpack.node",
-							"layers": {
-								"nodejs": {
-									"data": {"akey": "avalue", "bkey": "bvalue"}
+				appImageMetadata = lifecycle.AppImageMetadata{
+					Buildpacks: []lifecycle.BuildpackMetadata{
+						lifecycle.BuildpackMetadata{
+							ID: "buildpack.node",
+							Layers: map[string]lifecycle.LayerMetadata{
+								"nodejs": lifecycle.LayerMetadata{
+									Data: map[string]string{"akey": "avalue", "bkey": "bvalue"},
 								},
-								"node_modules": {
-									"data": {"version": "1234"}
-								}
-							}
+								"node_modules": lifecycle.LayerMetadata{
+									Data: map[string]string{"version": "1234"},
+								},
+							},
 						},
-						{
-							"key": "buildpack.go",
-							"layers": {
-								"go": {
-									"data": {"version": "1.10"}
-								}
-							}
-						}
-					]
-				}`}
-				image.EXPECT().ConfigFile().Return(configFile, nil)
+						lifecycle.BuildpackMetadata{
+							ID: "buildpack.go",
+							Layers: map[string]lifecycle.LayerMetadata{
+								"go": lifecycle.LayerMetadata{
+									Data: map[string]string{"version": "1.10"},
+								},
+							},
+						},
+					},
+				}
 			})
 
 			it("should use labels to populate the launch dir", func() {
-				if err := analyzer.Analyze(launchDir, "", image); err != nil {
+				if err := analyzer.Analyze(launchDir, appImageMetadata); err != nil {
 					t.Fatalf("Error: %s\n", err)
 				}
 
@@ -99,97 +101,38 @@ func testAnalyzer(t *testing.T, when spec.G, it spec.S) {
 					} else if string(txt) != data.expected {
 						t.Fatalf(`Error: expected "%s" to be toml encoded %s`, txt, data.name)
 					}
-				}
-			})
-		})
-
-		when("metadata is passed in as a string", func() {
-			it("uses that config instead of accessing the image", func() {
-				metadataJSON := `{
-					"buildpacks": [
-						{
-							"key": "buildpack.node",
-							"layers": {
-								"nodejs": {
-									"data": {"akey": "avalue", "bkey": "bvalue"}
-								},
-								"node_modules": {
-									"data": {"version": "1234"}
-								}
-							}
-						},
-						{
-							"key": "buildpack.go",
-							"layers": {
-								"go": {
-									"data": {"version": "1.10"}
-								}
-							}
-						}
-					]
-				}`
-
-				if err := analyzer.Analyze(launchDir, metadataJSON, image); err != nil {
-					t.Fatalf("Error: %s\n", err)
-				}
-
-				for _, data := range []struct{ name, expected string }{
-					{"buildpack.node/nodejs.toml", `akey = "avalue"` + "\n" + `bkey = "bvalue"` + "\n"},
-					{"buildpack.node/node_modules.toml", `version = "1234"` + "\n"},
-					{"buildpack.go/go.toml", `version = "1.10"` + "\n"},
-				} {
-					if txt, err := ioutil.ReadFile(filepath.Join(launchDir, data.name)); err != nil {
-						t.Fatalf("Error: %s\n", err)
-					} else if string(txt) != data.expected {
-						t.Fatalf(`Error: expected "%s" to be toml encoded %s`, txt, data.name)
-					}
-				}
-			})
-		})
-
-		when("image exists but is missing config", func() {
-			it.Before(func() {
-				var configFile = &v1.ConfigFile{}
-				image.EXPECT().ConfigFile().Return(configFile, nil)
-			})
-
-			it("should do nothing and succeed", func() {
-				if err := analyzer.Analyze(launchDir, "", image); err != nil {
-					t.Fatalf("Error: %s\n", err)
 				}
 			})
 		})
 
 		when("image has buildpacks that won't be run", func() {
 			it.Before(func() {
-				var configFile = &v1.ConfigFile{}
-				configFile.Config.Labels = map[string]string{lifecycle.MetadataLabel: `{
-					"buildpacks": [
-						{
-							"key": "buildpack.node",
-							"layers": {
-								"node_modules": {
-									"data": {"version": "1234"}
-								}
-							}
+				appImageMetadata = lifecycle.AppImageMetadata{
+					Buildpacks: []lifecycle.BuildpackMetadata{
+						lifecycle.BuildpackMetadata{
+							ID: "buildpack.node",
+							Layers: map[string]lifecycle.LayerMetadata{
+								"node_modules": lifecycle.LayerMetadata{
+									Data: map[string]string{"version": "1234"},
+								},
+							},
 						},
-						{
-							"key": "buildpack.go",
-							"layers": {
-								"go": {
-									"data": {"version": "1.10"}
-								}
-							}
-						}
-					]
-				}`}
-				image.EXPECT().ConfigFile().Return(configFile, nil)
+						lifecycle.BuildpackMetadata{
+							ID: "buildpack.go",
+							Layers: map[string]lifecycle.LayerMetadata{
+								"go": lifecycle.LayerMetadata{
+									Data: map[string]string{"version": "1.10"},
+								},
+							},
+						},
+					},
+				}
 			})
 
 			it("should only write layer TOML files that correspond to detected buildpacks", func() {
 				analyzer.Buildpacks = []*lifecycle.Buildpack{{ID: "buildpack.go"}}
 
-				if err := analyzer.Analyze(launchDir, "", image); err != nil {
+				if err := analyzer.Analyze(launchDir, appImageMetadata); err != nil {
 					t.Fatalf("Error: %s\n", err)
 				}
 
@@ -205,4 +148,176 @@ func testAnalyzer(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 	})
+
+	when("#GetMetadata", func() {
+		var (
+			image        *testmock.MockImage
+			repoStore    *testmock.MockStore
+			newRepoStore func(string) (img.Store, error)
+		)
+		it.Before(func() {
+			image = testmock.NewMockImage(mockCtrl)
+			repoStore = testmock.NewMockStore(mockCtrl)
+			newRepoStore = func(repoName string) (img.Store, error) {
+				if repoName == "my_org/my_repo" {
+					return repoStore, nil
+				} else {
+					return nil, errors.New("different reponame")
+				}
+			}
+		})
+
+		when("image has compatible metadata", func() {
+			it.Before(func() {
+				repoStore.EXPECT().Image().Return(image, nil)
+				image.EXPECT().RawManifest().Return(nil, nil)
+				image.EXPECT().ConfigFile().Return(&v1.ConfigFile{
+					Config: v1.Config{
+						Labels: map[string]string{
+							"io.buildpacks.lifecycle.metadata": `{"key":"value"}`,
+						},
+					},
+				}, nil)
+			})
+			it("returns the metadata", func() {
+				metadata, err := analyzer.GetMetadata(newRepoStore, "my_org/my_repo")
+				assertNil(t, err)
+				assertEq(t, metadata, `{"key":"value"}`)
+			})
+		})
+
+		when("image does not exist", func() {
+			it("warns user and returns", func() {
+				_, err := analyzer.GetMetadata(newRepoStore, "my_org/unknown")
+				if !strings.Contains(err.Error(), "different reponame") {
+					t.Fatalf("expected an error: %#v", err)
+				}
+			})
+		})
+
+		when("error obtaining image from repoStore", func() {
+			it.Before(func() {
+				repoStore.EXPECT().Image().Return(nil, errors.New("MyError"))
+			})
+			it("warns user and returns", func() {
+				metadata, err := analyzer.GetMetadata(newRepoStore, "my_org/my_repo")
+				assertNil(t, err)
+				assertEq(t, metadata, "")
+				if !strings.Contains(stdout.String(), "WARNING: skipping analyze, authenticating to registry failed: MyError") {
+					t.Fatalf("expected warning in stdout: %s", stdout.String())
+				}
+			})
+		})
+
+		when("using a registry #Image returns but #RawManifest has errors", func() {
+			it.Before(func() {
+				repoStore.EXPECT().Image().Return(image, nil)
+			})
+			when("#RawManifest returns an UnauthorizedErrorCode", func() {
+				it.Before(func() {
+					image.EXPECT().RawManifest().Return(nil,
+						&remote.Error{Errors: []remote.Diagnostic{{Code: remote.UnauthorizedErrorCode}}},
+					)
+				})
+				it("warns user and returns", func() {
+					metadata, err := analyzer.GetMetadata(newRepoStore, "my_org/my_repo")
+					assertNil(t, err)
+					assertEq(t, metadata, "")
+					if !strings.Contains(stdout.String(), "WARNING: skipping analyze, image not found or requires authentication to access:") {
+						t.Fatalf("expected warning in stdout: %s", stdout.String())
+					}
+				})
+			})
+			when("#RawManifest returns a ManifestUnknownErrorCode", func() {
+				it.Before(func() {
+					image.EXPECT().RawManifest().Return(nil,
+						&remote.Error{Errors: []remote.Diagnostic{{Code: remote.ManifestUnknownErrorCode}}},
+					)
+				})
+				it("warns user and returns", func() {
+					metadata, err := analyzer.GetMetadata(newRepoStore, "my_org/my_repo")
+					assertNil(t, err)
+					assertEq(t, metadata, "")
+					if !strings.Contains(stdout.String(), "WARNING: skipping analyze, image not found or requires authentication to access:") {
+						t.Fatalf("expected warning in stdout: %s", stdout.String())
+					}
+				})
+			})
+			when("#RawManifest returns a different error", func() {
+				it.Before(func() {
+					image.EXPECT().RawManifest().Return(nil,
+						&remote.Error{Errors: []remote.Diagnostic{{Code: remote.UnsupportedErrorCode}}},
+					)
+				})
+				it("fails", func() {
+					_, err := analyzer.GetMetadata(newRepoStore, "my_org/my_repo")
+					assertNotNil(t, err)
+				})
+			})
+			when("#RawManifest returns a completely different error", func() {
+				it.Before(func() {
+					image.EXPECT().RawManifest().Return(nil, errors.New("error"))
+				})
+				it("fails", func() {
+					_, err := analyzer.GetMetadata(newRepoStore, "my_org/my_repo")
+					assertNotNil(t, err)
+				})
+			})
+		})
+
+		when("error obtaining configfile from repoStore", func() {
+			it.Before(func() {
+				repoStore.EXPECT().Image().Return(image, nil)
+				image.EXPECT().RawManifest().Return(nil, nil)
+				image.EXPECT().ConfigFile().Return(nil, errors.New("MyError"))
+			})
+			it("fails", func() {
+				_, err := analyzer.GetMetadata(newRepoStore, "my_org/my_repo")
+				assertNotNil(t, err)
+			})
+		})
+
+		when("required label is not found", func() {
+			it.Before(func() {
+				repoStore.EXPECT().Image().Return(image, nil)
+				image.EXPECT().RawManifest().Return(nil, nil)
+				image.EXPECT().ConfigFile().Return(&v1.ConfigFile{
+					Config: v1.Config{
+						Labels: map[string]string{
+							"otherlabel": `{"key":"value"}`,
+						},
+					},
+				}, nil)
+			})
+			it("warns user and returns", func() {
+				metadata, err := analyzer.GetMetadata(newRepoStore, "my_org/my_repo")
+				assertNil(t, err)
+				assertEq(t, metadata, "")
+				if !strings.Contains(stdout.String(), "WARNING: skipping analyze, previous image metadata was not found") {
+					t.Fatalf("expected warning in stdout: %s", stdout.String())
+				}
+			})
+		})
+	})
+}
+
+func assertNil(t *testing.T, actual interface{}) {
+	t.Helper()
+	if actual != nil {
+		t.Fatalf("Expected nil: %s", actual)
+	}
+}
+
+func assertNotNil(t *testing.T, actual interface{}) {
+	t.Helper()
+	if actual == nil {
+		t.Fatal("Expected not nil")
+	}
+}
+
+func assertEq(t *testing.T, actual, expected interface{}) {
+	t.Helper()
+	if diff := cmp.Diff(actual, expected); diff != "" {
+		t.Fatal(diff)
+	}
 }

--- a/cmd/analyzer/main.go
+++ b/cmd/analyzer/main.go
@@ -71,7 +71,7 @@ func analyzer() error {
 		if useDaemon {
 			newRepoStore = img.NewDaemon
 		}
-		metadata, err = analyzer.GetMetadata(newRepoStore)
+		metadata, err = analyzer.GetMetadata(newRepoStore, repoName)
 		if err != nil {
 			return cmd.FailErr(err, "access image metadata from image", metadataPath)
 		}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -50,6 +50,10 @@ func FlagRunImage(image *string) {
 	flag.StringVar(image, "image", os.Getenv(EnvRunImage), "reference to run image")
 }
 
+func FlagMetadata(metadata *string) {
+	flag.StringVar(metadata, "metadata", "", "previous metadata as string (instead of image)")
+}
+
 func FlagUseDaemon(use *bool) {
 	flag.BoolVar(use, "daemon", boolEnv(EnvUseDaemon), "export to docker daemon")
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -50,8 +50,8 @@ func FlagRunImage(image *string) {
 	flag.StringVar(image, "image", os.Getenv(EnvRunImage), "reference to run image")
 }
 
-func FlagMetadata(metadata *string) {
-	flag.StringVar(metadata, "metadata", "", "previous metadata as string (instead of image)")
+func FlagMetadataPath(metadata *string) {
+	flag.StringVar(metadata, "metadata", "", "path to json containing image metadata for previous image")
 }
 
 func FlagUseDaemon(use *bool) {


### PR DESCRIPTION
This enables users to extract the previous image's metadata seperately and then pass it to the docker image to run