### PR TITLE
Add PACK_GROUP_ID as duplicate of PACK_USER_GID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN \
   useradd --uid ${pack_uid} --gid ${pack_gid} -m -s /bin/bash pack
 
 ENV PACK_USER_ID=${pack_uid}
+ENV PACK_GROUP_ID=${pack_gid}
 ENV PACK_USER_GID=${pack_gid}
 
 COPY --from=builder /go/bin /lifecycle


### PR DESCRIPTION
PACK_USER_GID is deprecated, leaving here until tooling updates

[https://github.com/buildpack/pack/issues/50]