### PR TITLE
Exporter can accept UID & GID

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -7,9 +7,10 @@ import (
 	"path/filepath"
 
 	"github.com/BurntSushi/toml"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+
 	"github.com/buildpack/lifecycle/cmd"
 	"github.com/buildpack/lifecycle/img"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
 type Analyzer struct {

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -10,15 +10,16 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/buildpack/lifecycle"
-	"github.com/buildpack/lifecycle/img"
-	"github.com/buildpack/lifecycle/testmock"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
+
+	"github.com/buildpack/lifecycle"
+	"github.com/buildpack/lifecycle/img"
+	"github.com/buildpack/lifecycle/testmock"
 )
 
 func TestAnalyzer(t *testing.T) {

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/BurntSushi/toml"
+
 	"github.com/buildpack/lifecycle"
 	"github.com/buildpack/lifecycle/cmd"
 	"github.com/buildpack/lifecycle/img"

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	"github.com/BurntSushi/toml"
-
 	"github.com/buildpack/lifecycle"
 	"github.com/buildpack/lifecycle/cmd"
 	"github.com/buildpack/lifecycle/img"
@@ -20,6 +19,8 @@ var (
 	groupPath  string
 	useDaemon  bool
 	useHelpers bool
+	uid        int
+	gid        int
 )
 
 func init() {
@@ -28,6 +29,8 @@ func init() {
 	cmd.FlagGroupPath(&groupPath)
 	cmd.FlagUseDaemon(&useDaemon)
 	cmd.FlagUseHelpers(&useHelpers)
+	cmd.FlagUID(&uid)
+	cmd.FlagGID(&gid)
 }
 
 func main() {
@@ -94,6 +97,8 @@ func export() error {
 		TmpDir:     tmpDir,
 		Out:        os.Stdout,
 		Err:        os.Stderr,
+		UID:        uid,
+		GID:        gid,
 	}
 	newImage, err := exporter.Export(
 		launchDir,

--- a/env_test.go
+++ b/env_test.go
@@ -2,16 +2,15 @@ package lifecycle_test
 
 import (
 	"errors"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
-
-	"io/ioutil"
-	"strings"
 
 	"github.com/buildpack/lifecycle"
 )

--- a/exporter.go
+++ b/exporter.go
@@ -11,10 +11,11 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
-	"github.com/buildpack/lifecycle/img"
 	"github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/pkg/errors"
+
+	"github.com/buildpack/lifecycle/img"
 )
 
 type Exporter struct {

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -9,18 +9,19 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"os/user"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/buildpack/lifecycle"
+	"github.com/buildpack/lifecycle/img"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
-
-	"github.com/buildpack/lifecycle"
-	"github.com/buildpack/lifecycle/img"
 )
 
 func TestExporter(t *testing.T) {
@@ -125,6 +126,54 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 			} else if diff := cmp.Diff(strings.TrimSpace(txt), "echo text from layer 2"); diff != "" {
 				t.Fatal("workspace/buildpack.id/layer2/file-from-layer-2: (-got +want)", diff)
 			}
+
+			t.Log("uses filesystem uid/gid for image layers")
+			currentUser, err := user.Current()
+			if err != nil {
+				t.Fatalf("Error: %s\n", err)
+			}
+			if uid, gid, err := getImageFileUidGid(image, data.App.SHA, "workspace/app/subdir/myfile.txt"); err != nil {
+				t.Fatalf("Error: %s\n", err)
+			} else if diff := cmp.Diff(strconv.Itoa(uid), currentUser.Uid); diff != "" {
+				t.Fatalf(`workspace/app/subdir/myfile.txt: (-got +want)\n%s`, diff)
+			} else if diff := cmp.Diff(strconv.Itoa(gid), currentUser.Gid); diff != "" {
+				t.Fatalf(`workspace/app/subdir/myfile.txt: (-got +want)\n%s`, diff)
+			}
+		})
+
+		when("exporter has UID/GID set", func() {
+			it.Before(func() {
+				exporter.UID = 1234
+				exporter.GID = 5678
+			})
+			it("sets uid/gid on the layer files", func() {
+				image, err := exporter.Export("testdata/exporter/first/launch", runImage, nil)
+				if err != nil {
+					t.Fatalf("Error: %s\n", err)
+				}
+				data, err := getMetadata(image)
+				if err != nil {
+					t.Fatalf("Error: %s\n", err)
+				}
+
+				// File
+				if uid, gid, err := getImageFileUidGid(image, data.App.SHA, "workspace/app/subdir/myfile.txt"); err != nil {
+					t.Fatalf("Error: %s\n", err)
+				} else if diff := cmp.Diff(uid, 1234); diff != "" {
+					t.Fatalf(`workspace/app/subdir/myfile.txt: (-got +want)\n%s`, diff)
+				} else if diff := cmp.Diff(gid, 5678); diff != "" {
+					t.Fatalf(`workspace/app/subdir/myfile.txt: (-got +want)\n%s`, diff)
+				}
+
+				// Directory
+				if uid, gid, err := getImageFileUidGid(image, data.App.SHA, "workspace/app/subdir"); err != nil {
+					t.Fatalf("Error: %s\n", err)
+				} else if diff := cmp.Diff(uid, 1234); diff != "" {
+					t.Fatalf(`workspace/app/subdir: (-got +want)\n%s`, diff)
+				} else if diff := cmp.Diff(gid, 5678); diff != "" {
+					t.Fatalf(`workspace/app/subdir: (-got +want)\n%s`, diff)
+				}
+			})
 		})
 
 		when("rebuilding when layer TOML exists without directory", func() {
@@ -219,6 +268,34 @@ func getImageFile(image v1.Image, layerDigest, path string) (string, error) {
 		return "", err
 	}
 	return getLayerFile(layer, path)
+}
+
+func getImageFileUidGid(image v1.Image, layerDigest, path string) (int, int, error) {
+	hash, err := v1.NewHash(layerDigest)
+	if err != nil {
+		return 0, 0, err
+	}
+	layer, err := image.LayerByDiffID(hash)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	r, err := layer.Uncompressed()
+	if err != nil {
+		return 0, 0, err
+	}
+	defer r.Close()
+	tr := tar.NewReader(r)
+	for {
+		header, err := tr.Next()
+		if err != nil {
+			return 0, 0, err
+		}
+
+		if header.Name == path {
+			return header.Uid, header.Gid, err
+		}
+	}
 }
 
 type metadata struct {

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -270,7 +270,7 @@ func getImageFile(image v1.Image, layerDigest, path string) (string, error) {
 	return getLayerFile(layer, path)
 }
 
-func getImageFileOwner(image v1.Image, layerDigest, path string) (int, int, error) {
+func getImageFileOwner(image v1.Image, layerDigest, path string) (uid, gid int, err error) {
 	hash, err := v1.NewHash(layerDigest)
 	if err != nil {
 		return 0, 0, err

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -15,13 +15,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/buildpack/lifecycle"
-	"github.com/buildpack/lifecycle/img"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
+
+	"github.com/buildpack/lifecycle"
+	"github.com/buildpack/lifecycle/img"
 )
 
 func TestExporter(t *testing.T) {

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -132,7 +132,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 			if err != nil {
 				t.Fatalf("Error: %s\n", err)
 			}
-			if uid, gid, err := getImageFileUidGid(image, data.App.SHA, "workspace/app/subdir/myfile.txt"); err != nil {
+			if uid, gid, err := getImageFileOwner(image, data.App.SHA, "workspace/app/subdir/myfile.txt"); err != nil {
 				t.Fatalf("Error: %s\n", err)
 			} else if diff := cmp.Diff(strconv.Itoa(uid), currentUser.Uid); diff != "" {
 				t.Fatalf(`workspace/app/subdir/myfile.txt: (-got +want)\n%s`, diff)
@@ -157,7 +157,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 				}
 
 				// File
-				if uid, gid, err := getImageFileUidGid(image, data.App.SHA, "workspace/app/subdir/myfile.txt"); err != nil {
+				if uid, gid, err := getImageFileOwner(image, data.App.SHA, "workspace/app/subdir/myfile.txt"); err != nil {
 					t.Fatalf("Error: %s\n", err)
 				} else if diff := cmp.Diff(uid, 1234); diff != "" {
 					t.Fatalf(`workspace/app/subdir/myfile.txt: (-got +want)\n%s`, diff)
@@ -166,7 +166,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 				}
 
 				// Directory
-				if uid, gid, err := getImageFileUidGid(image, data.App.SHA, "workspace/app/subdir"); err != nil {
+				if uid, gid, err := getImageFileOwner(image, data.App.SHA, "workspace/app/subdir"); err != nil {
 					t.Fatalf("Error: %s\n", err)
 				} else if diff := cmp.Diff(uid, 1234); diff != "" {
 					t.Fatalf(`workspace/app/subdir: (-got +want)\n%s`, diff)
@@ -270,7 +270,7 @@ func getImageFile(image v1.Image, layerDigest, path string) (string, error) {
 	return getLayerFile(layer, path)
 }
 
-func getImageFileUidGid(image v1.Image, layerDigest, path string) (int, int, error) {
+func getImageFileOwner(image v1.Image, layerDigest, path string) (int, int, error) {
 	hash, err := v1.NewHash(layerDigest)
 	if err != nil {
 		return 0, 0, err

--- a/knative_test.go
+++ b/knative_test.go
@@ -2,14 +2,14 @@ package lifecycle_test
 
 import (
 	"io/ioutil"
-	"testing"
-
 	"os"
 	"path/filepath"
+	"testing"
 
-	"github.com/buildpack/lifecycle"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
+
+	"github.com/buildpack/lifecycle"
 )
 
 func TestKnative(t *testing.T) {

--- a/launcher_test.go
+++ b/launcher_test.go
@@ -7,10 +7,11 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/buildpack/lifecycle"
 	"github.com/google/go-cmp/cmp"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
+
+	"github.com/buildpack/lifecycle"
 )
 
 func TestLauncher(t *testing.T) {


### PR DESCRIPTION
Setting UID & GID will set the values on image layer directories and
files.

This allows files to be temporarily stored on file systems where the
user does not have privileges to set uid & gid.

[https://github.com/buildpack/pack/issues/50]

Signed-off-by: Dave Goddard <dave@goddard.id.au>