### PR TITLE
Metadata records run image top layer

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -27,13 +27,13 @@ type Exporter struct {
 }
 
 func (e *Exporter) Export(launchDirSrc, launchDirDst string, runImage, origImage v1.Image) (v1.Image, error) {
-	runImageDigest, err := runImage.Digest()
+	runLayerDigest, err := img.TopLayerDigest(runImage)
 	if err != nil {
 		return nil, errors.Wrap(err, "find run image digest")
 	}
 	metadata := AppImageMetadata{
 		RunImage: RunImageMetadata{
-			SHA: runImageDigest.String(),
+			TopLayer: runLayerDigest.String(),
 		},
 	}
 

--- a/exporter.go
+++ b/exporter.go
@@ -27,17 +27,13 @@ type Exporter struct {
 }
 
 func (e *Exporter) Export(launchDirSrc, launchDirDst string, runImage, origImage v1.Image) (v1.Image, error) {
-	runLayerDigest, err := img.TopLayerDigest(runImage)
-	if err != nil {
-		return nil, errors.Wrap(err, "find run image digest")
-	}
-	metadata := AppImageMetadata{
-		RunImage: RunImageMetadata{
-			TopLayer: runLayerDigest.String(),
-		},
+	metadata := AppImageMetadata{}
+
+	if err := addRunImageMetadata(runImage, &metadata); err != nil {
+		return nil, err
 	}
 
-	repoImage, topLayerDigest, err := e.addDirAsLayer(
+	repoImage, appLayerDigest, err := e.addDirAsLayer(
 		runImage,
 		filepath.Join(e.TmpDir, "app.tgz"),
 		filepath.Join(launchDirSrc, "app"),
@@ -46,9 +42,9 @@ func (e *Exporter) Export(launchDirSrc, launchDirDst string, runImage, origImage
 	if err != nil {
 		return nil, errors.Wrap(err, "append app layer to run image")
 	}
-	metadata.App.SHA = topLayerDigest
+	metadata.App.SHA = appLayerDigest
 
-	repoImage, topLayerDigest, err = e.addDirAsLayer(
+	repoImage, configLayerDigest, err := e.addDirAsLayer(
 		repoImage,
 		filepath.Join(e.TmpDir, "config.tgz"),
 		filepath.Join(launchDirSrc, "config"),
@@ -57,7 +53,7 @@ func (e *Exporter) Export(launchDirSrc, launchDirDst string, runImage, origImage
 	if err != nil {
 		return nil, errors.Wrap(err, "append config layer to run image")
 	}
-	metadata.Config.SHA = topLayerDigest
+	metadata.Config.SHA = configLayerDigest
 
 	var bpMetadata []BuildpackMetadata
 	if origImage != nil {
@@ -103,6 +99,21 @@ func (e *Exporter) Export(launchDirSrc, launchDirDst string, runImage, origImage
 	}
 
 	return repoImage, nil
+}
+func addRunImageMetadata(runImage v1.Image, metadata *AppImageMetadata) error {
+	runLayerDigest, err := img.TopLayerDigest(runImage)
+	if err != nil {
+		return errors.Wrap(err, "find run image digest")
+	}
+	runImageDigest, err := runImage.Digest()
+	if err != nil {
+		return errors.Wrap(err, "find run image digest")
+	}
+	metadata.RunImage = RunImageMetadata{
+		TopLayer: runLayerDigest.String(),
+		SHA:      runImageDigest.String(),
+	}
+	return nil
 }
 
 func (e *Exporter) addBuildpackLayer(

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -86,12 +86,12 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 				t.Fatal(diff)
 			}
 
-			t.Log("sets run image SHA in metadata")
-			runImageDigest, err := runImage.Digest()
+			t.Log("sets run image top layer TopLayer in metadata")
+			runImageLayerDigest, err := topLayer(runImage)
 			if err != nil {
 				t.Fatalf("Error: %s\n", err)
 			}
-			if diff := cmp.Diff(data.RunImage.SHA, runImageDigest.String()); diff != "" {
+			if diff := cmp.Diff(data.RunImage.TopLayer, runImageLayerDigest.String()); diff != "" {
 				t.Fatalf(`RunImage digest did not match: (-got +want)\n%s`, diff)
 			}
 
@@ -234,6 +234,14 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 	}, spec.Parallel(), spec.Report(report.Terminal{}))
 }
 
+func topLayer(image v1.Image) (v1.Hash, error) {
+	layers, err := image.Layers()
+	if err != nil {
+		return v1.Hash{}, err
+	}
+	return layers[len(layers)-1].Digest()
+}
+
 func getBusyboxWithEntrypoint() (v1.Image, error) {
 	runImageStore, err := img.NewRegistry("busybox")
 	if err != nil {
@@ -315,7 +323,7 @@ func getImageFileOwner(image v1.Image, layerDigest, path string) (uid, gid int, 
 
 type metadata struct {
 	RunImage struct {
-		SHA string `json:"sha"`
+		TopLayer string `json:"topLayer"`
 	} `json:"runimage"`
 	App struct {
 		SHA string `json:"sha"`

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -86,12 +86,21 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 				t.Fatal(diff)
 			}
 
-			t.Log("sets run image top layer TopLayer in metadata")
+			t.Log("sets run image top layer in metadata")
 			runImageLayerDigest, err := topLayer(runImage)
 			if err != nil {
 				t.Fatalf("Error: %s\n", err)
 			}
 			if diff := cmp.Diff(data.RunImage.TopLayer, runImageLayerDigest.String()); diff != "" {
+				t.Fatalf(`RunImage digest did not match: (-got +want)\n%s`, diff)
+			}
+
+			t.Log("sets run image SHA in metadata")
+			runImageDigest, err := runImage.Digest()
+			if err != nil {
+				t.Fatalf("Error: %s\n", err)
+			}
+			if diff := cmp.Diff(data.RunImage.SHA, runImageDigest.String()); diff != "" {
 				t.Fatalf(`RunImage digest did not match: (-got +want)\n%s`, diff)
 			}
 
@@ -324,7 +333,8 @@ func getImageFileOwner(image v1.Image, layerDigest, path string) (uid, gid int, 
 type metadata struct {
 	RunImage struct {
 		TopLayer string `json:"topLayer"`
-	} `json:"runimage"`
+		SHA      string `json:"sha"`
+	} `json:"runImage"`
 	App struct {
 		SHA string `json:"sha"`
 	} `json:"app"`

--- a/img/actions.go
+++ b/img/actions.go
@@ -44,6 +44,14 @@ func Rebase(orig v1.Image, newBase v1.Image, oldBaseFinder ImageFinder) (v1.Imag
 	return image, nil
 }
 
+func TopLayerDigest(image v1.Image) (v1.Hash, error) {
+	layers, err := image.Layers()
+	if err != nil {
+		return v1.Hash{}, err
+	}
+	return layers[len(layers)-1].Digest()
+}
+
 func Label(image v1.Image, k, v string) (v1.Image, error) {
 	configFile, err := image.ConfigFile()
 	if err != nil {

--- a/metadata.go
+++ b/metadata.go
@@ -9,7 +9,7 @@ type AppImageMetadata struct {
 	App        AppMetadata         `json:"app"`
 	Config     ConfigMetadata      `json:"config"`
 	Buildpacks []BuildpackMetadata `json:"buildpacks"`
-	RunImage   RunImageMetadata    `json:"runimage"`
+	RunImage   RunImageMetadata    `json:"runImage"`
 }
 
 type AppMetadata struct {
@@ -34,4 +34,5 @@ type LayerMetadata struct {
 type RunImageMetadata struct {
 	Name     string `json:"name"`
 	TopLayer string `json:"topLayer"`
+	SHA      string `json:"sha"`
 }

--- a/metadata.go
+++ b/metadata.go
@@ -32,6 +32,6 @@ type LayerMetadata struct {
 }
 
 type RunImageMetadata struct {
-	Name string `json:"name"`
-	SHA  string `json:"sha"`
+	Name     string `json:"name"`
+	TopLayer string `json:"topLayer"`
 }


### PR DESCRIPTION
* Stores top layer SHA instead of image SHA
* Allows rebasing without access to original run image

Signed-off-by: Emily Casey <ecasey@pivotal.io>