### PR TITLE
run image top layer is diff id

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -101,7 +101,7 @@ func (e *Exporter) Export(launchDirSrc, launchDirDst string, runImage, origImage
 	return repoImage, nil
 }
 func addRunImageMetadata(runImage v1.Image, metadata *AppImageMetadata) error {
-	runLayerDigest, err := img.TopLayerDigest(runImage)
+	runLayerDiffID, err := img.TopLayerDiffID(runImage)
 	if err != nil {
 		return errors.Wrap(err, "find run image digest")
 	}
@@ -110,7 +110,7 @@ func addRunImageMetadata(runImage v1.Image, metadata *AppImageMetadata) error {
 		return errors.Wrap(err, "find run image digest")
 	}
 	metadata.RunImage = RunImageMetadata{
-		TopLayer: runLayerDigest.String(),
+		TopLayer: runLayerDiffID.String(),
 		SHA:      runImageDigest.String(),
 	}
 	return nil

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -248,7 +248,7 @@ func topLayer(image v1.Image) (v1.Hash, error) {
 	if err != nil {
 		return v1.Hash{}, err
 	}
-	return layers[len(layers)-1].Digest()
+	return layers[len(layers)-1].DiffID()
 }
 
 func getBusyboxWithEntrypoint() (v1.Image, error) {

--- a/img/actions.go
+++ b/img/actions.go
@@ -44,12 +44,12 @@ func Rebase(orig v1.Image, newBase v1.Image, oldBaseFinder ImageFinder) (v1.Imag
 	return image, nil
 }
 
-func TopLayerDigest(image v1.Image) (v1.Hash, error) {
+func TopLayerDiffID(image v1.Image) (v1.Hash, error) {
 	layers, err := image.Layers()
 	if err != nil {
 		return v1.Hash{}, err
 	}
-	return layers[len(layers)-1].Digest()
+	return layers[len(layers)-1].DiffID()
 }
 
 func Label(image v1.Image, k, v string) (v1.Image, error) {

--- a/metadata.go
+++ b/metadata.go
@@ -32,7 +32,6 @@ type LayerMetadata struct {
 }
 
 type RunImageMetadata struct {
-	Name     string `json:"name"`
 	TopLayer string `json:"topLayer"`
 	SHA      string `json:"sha"`
 }


### PR DESCRIPTION
* Changes the run image metadata to record top layer DiffId instead of Digest
* Corrects mistake in https://github.com/buildpack/lifecycle/pull/28

Signed-off-by: Jacques Chester <jchester@pivotal.io>