### PR TITLE
Update README.MD to link to the formalized spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/buildpack/lifecycle.svg?branch=master)](https://travis-ci.org/buildpack/lifecycle)
 [![GoDoc](https://godoc.org/github.com/buildpack/lifecycle?status.svg)](https://godoc.org/github.com/buildpack/lifecycle)
 
-A reference implementation of [Buildpack API v3](https://docs.google.com/document/d/1D-f2wAX5CUmbgNzj7joFTpFdUYeirVatiFicwKsMnFo/edit).
+A reference implementation of [Buildpack API v3](https://github.com/buildpack/spec).
 
 ## Commands
 


### PR DESCRIPTION
Link in old readme is the working documement, which in tern links to the formalized spec. We should link to the formalized spec directly.