### PR TITLE
Add support for custom app directory with a cmd flag

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -39,7 +39,7 @@ type BuildMetadata struct {
 	Buildpacks []string  `toml:"buildpacks"`
 }
 
-func (b *Builder) Build(cacheDir, launchDir string, env BuildEnv) (*BuildMetadata, error) {
+func (b *Builder) Build(cacheDir, launchDir string, appDir string, env BuildEnv) (*BuildMetadata, error) {
 	procMap := processMap{}
 	var buildpackIDs []string
 	for _, bp := range b.Buildpacks {
@@ -58,7 +58,7 @@ func (b *Builder) Build(cacheDir, launchDir string, env BuildEnv) (*BuildMetadat
 		}
 		cmd := exec.Command(buildPath, b.PlatformDir, bpCacheDir, bpLaunchDir)
 		cmd.Env = env.List()
-		cmd.Dir = filepath.Join(launchDir, "app")
+		cmd.Dir = filepath.Join(appDir)
 		cmd.Stdin = bytes.NewBuffer(b.In)
 		cmd.Stdout = b.Out
 		cmd.Stderr = b.Err

--- a/builder_test.go
+++ b/builder_test.go
@@ -105,7 +105,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 					env.EXPECT().AddEnvDir(filepath.Join(cacheDir, "buildpack2-id", "cache-layer3", "env")),
 					env.EXPECT().AddEnvDir(filepath.Join(cacheDir, "buildpack2-id", "cache-layer4", "env")),
 				)
-				if _, err := builder.Build(cacheDir, launchDir, env); err != nil {
+				if _, err := builder.Build(cacheDir, launchDir, appDir, env); err != nil {
 					t.Fatalf("Error: %s\n", err)
 				}
 			})
@@ -117,7 +117,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 					filepath.Join(appDir, "launch-buildpack1", "launch-layer1"),
 					filepath.Join(appDir, "launch-buildpack2", "launch-layer2"),
 				)
-				if _, err := builder.Build(cacheDir, launchDir, env); err != nil {
+				if _, err := builder.Build(cacheDir, launchDir, appDir, env); err != nil {
 					t.Fatalf("Error: %s\n", err)
 				}
 				testExists(t,
@@ -127,7 +127,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("should return build metadata when processes are present", func() {
-				metadata, err := builder.Build(cacheDir, launchDir, env)
+				metadata, err := builder.Build(cacheDir, launchDir, appDir, env)
 				if err != nil {
 					t.Fatalf("Error: %s\n", err)
 				}
@@ -145,7 +145,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 
 			it("should return build metadata when processes are not present", func() {
 				mkfile(t, "test", filepath.Join(appDir, "skip-processes"))
-				metadata, err := builder.Build(cacheDir, launchDir, env)
+				metadata, err := builder.Build(cacheDir, launchDir, appDir, env)
 				if err != nil {
 					t.Fatalf("Error: %s\n", err)
 				}
@@ -161,7 +161,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 				mkfile(t, "some-data",
 					filepath.Join(platformDir, "env", "SOME_VAR"),
 				)
-				if _, err := builder.Build(cacheDir, launchDir, env); err != nil {
+				if _, err := builder.Build(cacheDir, launchDir, appDir, env); err != nil {
 					t.Fatalf("Error: %s\n", err)
 				}
 				testExists(t,
@@ -171,7 +171,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("should connect stdout and stdin to the terminal", func() {
-				if _, err := builder.Build(cacheDir, launchDir, env); err != nil {
+				if _, err := builder.Build(cacheDir, launchDir, appDir, env); err != nil {
 					t.Fatalf("Error: %s\n", err)
 				}
 				if stdout.String() != "STDOUT1\nSTDOUT2\n" {
@@ -186,7 +186,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 		when("building fails", func() {
 			it("should error when launch directories cannot be created", func() {
 				mkfile(t, "some-data", filepath.Join(launchDir, "buildpack1-id"))
-				_, err := builder.Build(cacheDir, launchDir, env)
+				_, err := builder.Build(cacheDir, launchDir, appDir, env)
 				if _, ok := err.(*os.PathError); !ok {
 					t.Fatalf("Incorrect error: %s\n", err)
 				}
@@ -194,7 +194,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 
 			it("should error when cache directories cannot be created", func() {
 				mkfile(t, "some-data", filepath.Join(cacheDir, "buildpack1-id"))
-				_, err := builder.Build(cacheDir, launchDir, env)
+				_, err := builder.Build(cacheDir, launchDir, appDir, env)
 				if _, ok := err.(*os.PathError); !ok {
 					t.Fatalf("Incorrect error: %s\n", err)
 				}
@@ -205,7 +205,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 				if err := os.RemoveAll(platformDir); err != nil {
 					t.Fatalf("Error: %s\n", err)
 				}
-				_, err := builder.Build(cacheDir, launchDir, env)
+				_, err := builder.Build(cacheDir, launchDir, appDir, env)
 				if _, ok := err.(*exec.ExitError); !ok {
 					t.Fatalf("Incorrect error: %s\n", err)
 				}
@@ -237,7 +237,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 						filepath.Join(appDir, "cache-buildpack1", "cache-layer1"),
 						filepath.Join(appDir, "cache-buildpack1", "cache-layer2"),
 					)
-					if _, err := builder.Build(cacheDir, launchDir, env); err != appendErr {
+					if _, err := builder.Build(cacheDir, launchDir, appDir, env); err != appendErr {
 						t.Fatalf("Incorrect error: %s\n", err)
 					}
 				})
@@ -246,7 +246,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 			it("should error when launch.toml is not writable", func() {
 				env.EXPECT().List().Return([]string{"ID=1"})
 				mkdir(t, filepath.Join(launchDir, "buildpack1-id", "launch.toml"))
-				if _, err := builder.Build(cacheDir, launchDir, env); err == nil {
+				if _, err := builder.Build(cacheDir, launchDir, appDir, env); err == nil {
 					t.Fatal("Expected error")
 				}
 			})

--- a/cmd/builder/main.go
+++ b/cmd/builder/main.go
@@ -15,6 +15,7 @@ var (
 	groupPath     string
 	planPath      string
 	launchDir     string
+	appDir        string
 	cacheDir      string
 	platformDir   string
 )
@@ -24,6 +25,7 @@ func init() {
 	cmd.FlagGroupPath(&groupPath)
 	cmd.FlagPlanPath(&planPath)
 	cmd.FlagLaunchDir(&launchDir)
+	cmd.FlagAppDir(&appDir)
 	cmd.FlagCacheDir(&cacheDir)
 	cmd.FlagPlatformDir(&platformDir)
 }
@@ -67,6 +69,7 @@ func build() error {
 	metadata, err := builder.Build(
 		cacheDir,
 		launchDir,
+		appDir,
 		env,
 	)
 	if err != nil {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	DefaultLaunchDir      = "/workspace"
+	DefaultAppDir         = "/workspace/app"
 	DefaultCacheDir       = "/cache"
 	DefaultBuildpacksDir  = "/buildpacks"
 	DefaultPlatformDir    = "/platform"
@@ -31,6 +32,14 @@ func FlagLaunchDir(dir *string) {
 
 func FlagLaunchDirSrc(dir *string) {
 	flag.StringVar(dir, "launch-src", DefaultLaunchDir, "path to source launch directory for export step")
+}
+
+func FlagAppDir(dir *string) {
+	flag.StringVar(dir, "app", DefaultAppDir, "path to app directory")
+}
+
+func FlagAppDirSrc(dir *string) {
+	flag.StringVar(dir, "app-src", DefaultAppDir, "path to app directory")
 }
 
 func FlagCacheDir(dir *string) {

--- a/cmd/detector/main.go
+++ b/cmd/detector/main.go
@@ -2,18 +2,16 @@ package main
 
 import (
 	"flag"
+	"github.com/buildpack/lifecycle"
+	"github.com/buildpack/lifecycle/cmd"
 	"io/ioutil"
 	"log"
 	"os"
-	"path/filepath"
-
-	"github.com/buildpack/lifecycle"
-	"github.com/buildpack/lifecycle/cmd"
 )
 
 var (
 	buildpacksDir string
-	launchDir     string
+	appDir        string
 	orderPath     string
 	groupPath     string
 	planPath      string
@@ -21,7 +19,7 @@ var (
 
 func init() {
 	cmd.FlagBuildpacksDir(&buildpacksDir)
-	cmd.FlagLaunchDir(&launchDir)
+	cmd.FlagAppDir(&appDir)
 	cmd.FlagOrderPath(&orderPath)
 
 	cmd.FlagGroupPath(&groupPath)
@@ -48,7 +46,7 @@ func detect() error {
 		return cmd.FailErr(err, "read buildpack order file")
 	}
 
-	info, group := order.Detect(logger, filepath.Join(launchDir, "app"))
+	info, group := order.Detect(logger, appDir)
 	if group == nil {
 		return cmd.FailCode(cmd.CodeFailedDetect, "detect")
 	}

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -18,6 +18,8 @@ var (
 	runImage     string
 	launchDir    string
 	launchDirSrc string
+	appDir       string
+	appDirSrc    string
 	groupPath    string
 	useDaemon    bool
 	useHelpers   bool
@@ -29,6 +31,8 @@ func init() {
 	cmd.FlagRunImage(&runImage)
 	cmd.FlagLaunchDir(&launchDir)
 	cmd.FlagLaunchDirSrc(&launchDirSrc)
+	cmd.FlagAppDir(&appDir)
+	cmd.FlagAppDirSrc(&appDirSrc)
 	cmd.FlagGroupPath(&groupPath)
 	cmd.FlagUseDaemon(&useDaemon)
 	cmd.FlagUseCredHelpers(&useHelpers)
@@ -106,6 +110,8 @@ func export() error {
 	newImage, err := exporter.Export(
 		launchDirSrc,
 		launchDir,
+		appDirSrc,
+		appDir,
 		stackImage,
 		origImage,
 	)

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	launchDir string
+	appDir    string
 )
 
 func main() {
@@ -32,6 +33,12 @@ func launch() error {
 	}
 	os.Unsetenv(lifecycle.EnvLaunchDir)
 
+	appDir := cmd.DefaultAppDir
+	if v := os.Getenv(lifecycle.EnvAppDir); v != "" {
+		appDir = v
+	}
+	os.Unsetenv(lifecycle.EnvAppDir)
+
 	var metadata lifecycle.BuildMetadata
 	metadataPath := filepath.Join(launchDir, "config", "metadata.toml")
 	if _, err := toml.DecodeFile(metadataPath, &metadata); err != nil {
@@ -41,6 +48,7 @@ func launch() error {
 	launcher := &lifecycle.Launcher{
 		DefaultProcessType: defaultProcessType,
 		LaunchDir:          launchDir,
+		AppDir:             appDir,
 		Processes:          metadata.Processes,
 		Buildpacks:         metadata.Buildpacks,
 		Exec:               syscall.Exec,

--- a/exporter.go
+++ b/exporter.go
@@ -26,7 +26,7 @@ type Exporter struct {
 	UID, GID   int
 }
 
-func (e *Exporter) Export(launchDirSrc, launchDirDst string, runImage, origImage v1.Image) (v1.Image, error) {
+func (e *Exporter) Export(launchDirSrc, launchDirDst string, appDirSrc string, appDirDst string, runImage, origImage v1.Image) (v1.Image, error) {
 	metadata := AppImageMetadata{}
 
 	if err := addRunImageMetadata(runImage, &metadata); err != nil {
@@ -36,8 +36,8 @@ func (e *Exporter) Export(launchDirSrc, launchDirDst string, runImage, origImage
 	repoImage, appLayerDigest, err := e.addDirAsLayer(
 		runImage,
 		filepath.Join(e.TmpDir, "app.tgz"),
-		filepath.Join(launchDirSrc, "app"),
-		filepath.Join(launchDirDst, "app"),
+		appDirSrc,
+		appDirDst,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "append app layer to run image")

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -72,7 +72,8 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("should process a simple launch directory", func() {
-			image, err := exporter.Export("testdata/exporter/first/launch", "/launch/dest", runImage, nil)
+			image, err := exporter.Export("testdata/exporter/first/launch", "/launch/dest",
+				"testdata/exporter/first/launch/app", "/launch/dest/app", runImage, nil)
 			if err != nil {
 				t.Fatalf("Error: %s\n", err)
 			}
@@ -164,7 +165,8 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 				exporter.GID = 5678
 			})
 			it("sets uid/gid on the layer files", func() {
-				image, err := exporter.Export("testdata/exporter/first/launch", "/launch/dest", runImage, nil)
+				image, err := exporter.Export("testdata/exporter/first/launch", "/launch/dest",
+					"testdata/exporter/first/launch/app", "/launch/dest/app", runImage, nil)
 				if err != nil {
 					t.Fatalf("Error: %s\n", err)
 				}
@@ -197,14 +199,16 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 			var firstImage v1.Image
 			it.Before(func() {
 				var err error
-				firstImage, err = exporter.Export("testdata/exporter/first/launch", "/launch/dest", runImage, nil)
+				firstImage, err = exporter.Export("testdata/exporter/first/launch", "/launch/dest",
+					"testdata/exporter/first/launch/app", "/launch/dest/app", runImage, nil)
 				if err != nil {
 					t.Fatalf("Error: %s\n", err)
 				}
 			})
 
 			it("should reuse layers if there is a layer TOML file", func() {
-				image, err := exporter.Export("testdata/exporter/second/launch", "/launch/dest", runImage, firstImage)
+				image, err := exporter.Export("testdata/exporter/second/launch", "/launch/dest",
+					"testdata/exporter/first/launch/app", "/launch/dest/app", runImage, firstImage)
 				if err != nil {
 					t.Fatalf("Error: %s\n", err)
 				}

--- a/launcher.go
+++ b/launcher.go
@@ -13,6 +13,7 @@ import (
 type Launcher struct {
 	DefaultProcessType string
 	LaunchDir          string
+	AppDir             string
 	Processes          []Process
 	Buildpacks         []string
 	Exec               func(argv0 string, argv []string, envv []string) error
@@ -26,7 +27,7 @@ func (l *Launcher) Launch(executable, startCommand string) error {
 		Map:     POSIXLaunchEnv,
 	}
 	if err := l.eachDir(l.LaunchDir, func(bp string) error {
-		if bp == "app" {
+		if l.AppDir == filepath.Join(l.LaunchDir, bp) {
 			return nil
 		}
 		bpPath := filepath.Join(l.LaunchDir, bp)
@@ -36,7 +37,7 @@ func (l *Launcher) Launch(executable, startCommand string) error {
 	}); err != nil {
 		return errors.Wrap(err, "modify env")
 	}
-	if err := os.Chdir(filepath.Join(l.LaunchDir, "app")); err != nil {
+	if err := os.Chdir(l.AppDir); err != nil {
 		return errors.Wrap(err, "change to app directory")
 	}
 
@@ -89,7 +90,7 @@ func (l *Launcher) profileD() (string, error) {
 		}
 	}
 
-	if err := appendIfFile(filepath.Join(l.LaunchDir, "app", ".profile")); err != nil {
+	if err := appendIfFile(filepath.Join(l.AppDir, ".profile")); err != nil {
 		return "", err
 	}
 

--- a/launcher_test.go
+++ b/launcher_test.go
@@ -44,6 +44,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 		launcher = &lifecycle.Launcher{
 			DefaultProcessType: "web",
 			LaunchDir:          filepath.Join(tmpDir, "launch"),
+			AppDir:             filepath.Join(tmpDir, "launch", "app"),
 			Processes: []lifecycle.Process{
 				{Type: "other", Command: "some-other-process"},
 				{Type: "web", Command: "some-web-process"},

--- a/metadata.go
+++ b/metadata.go
@@ -3,6 +3,7 @@ package lifecycle
 const (
 	MetadataLabel = "io.buildpacks.lifecycle.metadata"
 	EnvLaunchDir  = "PACK_LAUNCH_DIR"
+	EnvAppDir     = "PACK_APP_DIR"
 )
 
 type AppImageMetadata struct {


### PR DESCRIPTION
This allows for a custom named AppDir, or an AppDir that does not reside under the LaunchDir. The default remains `/workspace/app`, but this also cleans up some hard coded references to `"app"`.

I've also introduced a `PACK_APP_DIR` env var to support the launcher, which does not take flags. I'm not sure if this *should* be a flag. If not, we should maybe add this env var to the spec.

The primary use case is backwards compatibility with pre-v3 platforms, and the potential of a compatibility layer with older buildpacks (i.e. a "shim"). 

### Questions

* Should the `cmd.DefaultAppDir`  change if the LaunchDir is set to a custom value? 