### PR TITLE
Set entrypoint to /lifecycle/launcher during export

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -179,6 +179,11 @@ func (e *Exporter) ExportImage(launchDirDst, appDirDst string, runImage, origIma
 		return nil, errors.Wrap(err, "set app dir env var")
 	}
 
+	repoImage, err = img.Entrypoint(repoImage, []string{"/lifecycle/launcher"})
+	if err != nil {
+		return nil, errors.Wrap(err, "set entrypoint")
+	}
+
 	return repoImage, nil
 }
 

--- a/img/actions.go
+++ b/img/actions.go
@@ -82,6 +82,26 @@ func Env(image v1.Image, k, v string) (v1.Image, error) {
 	return mutate.Config(image, config)
 }
 
+func Entrypoint(image v1.Image, entrypoint []string) (v1.Image, error) {
+	configFile, err := image.ConfigFile()
+	if err != nil {
+		return nil, err
+	}
+	config := *configFile.Config.DeepCopy()
+	config.Entrypoint = entrypoint
+	return mutate.Config(image, config)
+}
+
+func Cmd(image v1.Image, cmd []string) (v1.Image, error) {
+	configFile, err := image.ConfigFile()
+	if err != nil {
+		return nil, err
+	}
+	config := *configFile.Config.DeepCopy()
+	config.Cmd = cmd
+	return mutate.Config(image, config)
+}
+
 func SetupCredHelpers(refs ...string) error {
 	dockerPath := filepath.Join(os.Getenv("HOME"), ".docker")
 	configPath := filepath.Join(dockerPath, "config.json")


### PR DESCRIPTION
This change set `ENTRYPOINT` to a fixed value of `/lifecycle/launcher`. This will ensure that CMDs like `/bin/bash` are started with the app environment.

It also adds a `Cmd` func for use by pack CLI.