### PR TITLE
launcher succeeds when buildpack dir does not exist

### DIFF
--- a/launcher.go
+++ b/launcher.go
@@ -54,7 +54,11 @@ func (l *Launcher) env() error {
 	return l.eachBuildpack(l.LayersDir, func(path string) error {
 		bpInfo, err := os.Stat(path)
 		if err != nil {
-			return errors.Wrap(err, "find buildpack directory")
+			if os.IsNotExist(err) {
+				return nil
+			} else {
+				return errors.Wrap(err, "find buildpack directory")
+			}
 		}
 		if os.SameFile(appInfo, bpInfo) {
 			return nil

--- a/launcher_test.go
+++ b/launcher_test.go
@@ -197,6 +197,21 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
+		when("metadata includes buildpacks that have not contributed layers", func() {
+			it.Before(func() {
+				launcher.Buildpacks = []string{"bp.3"}
+			})
+
+			it("ignores those buildpacks when setting the env", func() {
+				if err := launcher.Launch("/path/to/launcher", "start"); err != nil {
+					t.Fatal(err)
+				}
+				if len(syscallExecArgsColl) != 1 {
+					t.Fatalf("expected syscall.Exec to be called once: actual %v\n", syscallExecArgsColl)
+				}
+			})
+		})
+
 		when("buildpacks have provided profile.d scripts", func() {
 			it.Before(func() {
 				mkfile(t, "#!/usr/bin/env bash\necho hi from app\n",


### PR DESCRIPTION
* fixes bug in env setting logic
* succeed when metadata has buildpacks that did not contibute layers

Signed-off-by: Emily Casey <ecasey@pivotal.io>