### PR TITLE
Write uid/gid/pemissions for all parent directories in layer archives

### DIFF
--- a/exporter_test.go
+++ b/exporter_test.go
@@ -136,7 +136,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
           }
         },
         "layer5": {
-          "sha": "sha256:3b62bb1034a4542c79ec6117baedbd4fb8948879a519c646c5528621ffa3d196"
+          "sha": "sha256:994ca0ae66fac54fa60911f2a57ad932c471bcd616cf219d47ea3d794992c815"
         }
       }
     }
@@ -162,7 +162,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 					return nil
 				})
 				mockRunImage.EXPECT().ReuseLayer("orig-layer1-sha")
-				mockRunImage.EXPECT().ReuseLayer("sha256:3b62bb1034a4542c79ec6117baedbd4fb8948879a519c646c5528621ffa3d196")
+				mockRunImage.EXPECT().ReuseLayer("sha256:994ca0ae66fac54fa60911f2a57ad932c471bcd616cf219d47ea3d794992c815")
 				mockRunImage.EXPECT().AddLayer(gomock.Any()).DoAndReturn(func(layerPath string) error {
 					t.Log("adds buildpack layer2")
 					buildpackLayer2SHA = h.ComputeSHA256(t, layerPath)

--- a/fs/tar_test.go
+++ b/fs/tar_test.go
@@ -10,9 +10,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/buildpack/lifecycle/fs"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
+
+	"github.com/buildpack/lifecycle/fs"
+	h "github.com/buildpack/lifecycle/testhelpers"
 )
 
 func TestFS(t *testing.T) {
@@ -29,84 +31,86 @@ func testFS(t *testing.T, when spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 		tmpDir, err = ioutil.TempDir("", "create-tar-test")
-		if err != nil {
-			t.Fatalf("failed to create tmp dir %s: %s", tmpDir, err)
-		}
+		h.AssertNil(t, err)
 		src = filepath.Join("testdata", "dir-to-tar")
 	})
 
 	it.After(func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			t.Fatalf("failed to clean up tmp dir %s: %s", tmpDir, err)
-		}
+		err := os.RemoveAll(tmpDir)
+		h.AssertNil(t, err)
 	})
 
 	it("writes a tar to the dest dir", func() {
 		tarFile := filepath.Join(tmpDir, "some.tar")
 		err := fs.CreateTarFile(tarFile, src, "/dir-in-archive", 1234, 2345)
-		if err != nil {
-			t.Fatalf("CreateTarFile failed: %s", err)
-		}
+		h.AssertNil(t, err)
 		file, err := os.Open(tarFile)
-		if err != nil {
-			t.Fatalf("could not open tar file %s: %s", tarFile, err)
-		}
+		h.AssertNil(t, err)
+
 		defer file.Close()
 		tr := tar.NewReader(file)
 
 		t.Log("handles directories")
 		header, err := tr.Next()
-		if err != nil {
-			t.Fatalf("Failed to get next file: %s", err)
-		}
-		if header.Name != "/dir-in-archive" {
-			t.Fatalf(`expected directory with name /dir-in-archive, got %s`, header.Name)
-		}
+		h.AssertNil(t, err)
+		h.AssertEq(t, header.Name, "/dir-in-archive")
+
 		t.Log("handles regular files")
 		header, err = tr.Next()
-		if err != nil {
-			t.Fatalf("Failed to get next file: %s", err)
-		}
-		if header.Name != "/dir-in-archive/some-file.txt" {
-			t.Fatalf(`expected file with name /dir-in-archive/some-file.txt, got %s`, header.Name)
-		}
+		h.AssertNil(t, err)
+		h.AssertEq(t, header.Name, "/dir-in-archive/some-file.txt")
+
 		fileContents := make([]byte, header.Size, header.Size)
 		tr.Read(fileContents)
-		if string(fileContents) != "some-content" {
-			t.Fatalf(`expected to some-file.txt to have "some-contents" got %s`, string(fileContents))
-		}
-		if header.Uid != 1234 {
-			t.Fatalf(`expected some-file.txt to be owned by 1234 was %d`, header.Uid)
-		}
-		if header.Gid != 2345 {
-			t.Fatalf(`expected some-file.txt to be group 2345 was %d`, header.Gid)
-		}
+		h.AssertEq(t, string(fileContents), "some-content")
+		h.AssertEq(t, header.Uid, 1234)
+		h.AssertEq(t, header.Gid, 2345)
 
 		if runtime.GOOS != "windows" {
 			t.Log("handles sub dir")
 			_, err = tr.Next()
-			if err != nil {
-				t.Fatalf("Failed to get directory: %s", err)
-			}
+			h.AssertNil(t, err)
 
 			t.Log("handles symlinks")
 			header, err = tr.Next()
-			if err != nil {
-				t.Fatalf("Failed to get next file: %s", err)
+			h.AssertNil(t, err)
+
+			h.AssertEq(t, header.Name, "/dir-in-archive/sub-dir/link-file")
+			h.AssertEq(t, header.Uid, 1234)
+			h.AssertEq(t, header.Gid, 2345)
+			h.AssertEq(t, header.Linkname, "../some-file.txt")
+		}
+	})
+
+	it("writes parent directory headers with the expected permissions", func() {
+		tarFile := filepath.Join(tmpDir, "some.tar")
+		err := fs.CreateTarFile(tarFile, src, "/expectedDir-in-archive/with/nested/path", 1234, 2345)
+		h.AssertNil(t, err)
+
+		file, err := os.Open(tarFile)
+		h.AssertNil(t, err)
+		defer file.Close()
+		tr := tar.NewReader(file)
+
+		t.Log("handles directories")
+
+		for _, expectedDir := range []string{"/expectedDir-in-archive/", "/expectedDir-in-archive/with/", "/expectedDir-in-archive/with/nested/"} {
+			header, err := tr.Next()
+			h.AssertNil(t, err)
+
+			h.AssertEq(t, header.Name, expectedDir)
+
+			h.AssertEq(t, header.Uid, 1234)
+			h.AssertEq(t, header.Gid, 2345)
+
+			if header.Typeflag != tar.TypeDir {
+				t.Fatalf(`expected %s to be a directory`, expectedDir)
 			}
-			if header.Name != "/dir-in-archive/sub-dir/link-file" {
-				t.Fatalf(`expected file with name /dir-in-archive/sub-dir/link-file, got %s`, header.Name)
-			}
-			if header.Uid != 1234 {
-				t.Fatalf(`expected link-file to be owned by 1234 was %d`, header.Uid)
-			}
-			if header.Gid != 2345 {
-				t.Fatalf(`expected link-file to be group 2345 was %d`, header.Gid)
+			if header.Mode != 0755 {
+				t.Fatalf(`expected %s to have mode 0755`, expectedDir)
 			}
 
-			if header.Linkname != "../some-file.txt" {
-				t.Fatalf(`expected to link-file to have target "../some-file.txt" got "%s"`, header.Linkname)
-			}
+			t.Log("handles regular files")
 		}
 	})
 }


### PR DESCRIPTION
This prevents exported layers from having the wrong owner in an app image
https://github.com/buildpack/pack/issues/80

Signed-off-by: Matthew McNew mmcnew@pivotal.io