### PR TITLE
export launcher

### DIFF
--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -26,6 +26,8 @@ var (
 	gid         int
 )
 
+const launcherPath = "/lifecycle/launcher"
+
 func init() {
 	cmd.FlagRunImage(&runImageRef)
 	cmd.FlagLayersDir(&layersDir)
@@ -98,7 +100,7 @@ func export() error {
 		}
 	}
 
-	if err := exporter.Export(layersDir, appDir, runImage, origImage); err != nil {
+	if err := exporter.Export(layersDir, appDir, runImage, origImage, launcherPath); err != nil {
 		return cmd.FailErrCode(err, cmd.CodeFailedBuild)
 	}
 

--- a/image/factory.go
+++ b/image/factory.go
@@ -7,22 +7,6 @@ import (
 	"github.com/buildpack/lifecycle/fs"
 )
 
-type Image interface {
-	Label(string) (string, error)
-	Rename(name string)
-	Name() string
-	Digest() (string, error)
-	Rebase(string, Image) error
-	SetLabel(string, string) error
-	SetEnv(string, string) error
-	Env(key string) (string, error)
-	TopLayer() (string, error)
-	AddLayer(path string) error
-	ReuseLayer(sha string) error
-	Save() (string, error)
-	Found() (bool, error)
-}
-
 type Factory struct {
 	Docker *client.Client
 	FS     *fs.FS

--- a/image/image.go
+++ b/image/image.go
@@ -1,0 +1,19 @@
+package image
+
+type Image interface {
+	Name() string
+	Rename(name string)
+	Digest() (string, error)
+	Label(string) (string, error)
+	SetLabel(string, string) error
+	Env(key string) (string, error)
+	SetEnv(string, string) error
+	SetEntrypoint(...string) error
+	SetCmd(...string) error
+	Rebase(string, Image) error
+	AddLayer(path string) error
+	ReuseLayer(sha string) error
+	TopLayer() (string, error)
+	Save() (string, error)
+	Found() (bool, error)
+}

--- a/image/local.go
+++ b/image/local.go
@@ -178,7 +178,26 @@ func (l *local) SetLabel(key, val string) error {
 }
 
 func (l *local) SetEnv(key, val string) error {
+	if l.Inspect.Config == nil {
+		return fmt.Errorf("failed to set env var, image '%s' does not exist", l.RepoName)
+	}
 	l.Inspect.Config.Env = append(l.Inspect.Config.Env, fmt.Sprintf("%s=%s", key, val))
+	return nil
+}
+
+func (l *local) SetEntrypoint(ep ...string) error {
+	if l.Inspect.Config == nil {
+		return fmt.Errorf("failed to set entrypoint, image '%s' does not exist", l.RepoName)
+	}
+	l.Inspect.Config.Entrypoint = ep
+	return nil
+}
+
+func (l *local) SetCmd(cmd ...string) error {
+	if l.Inspect.Config == nil {
+		return fmt.Errorf("failed to set cmd, image '%s' does not exist", l.RepoName)
+	}
+	l.Inspect.Config.Cmd = cmd
 	return nil
 }
 

--- a/image/local_test.go
+++ b/image/local_test.go
@@ -258,6 +258,75 @@ func testLocal(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
+	when("#SetEntrypoint", func() {
+		var (
+			img    image.Image
+			origID string
+		)
+		it.Before(func() {
+			var err error
+			h.CreateImageOnLocal(t, dockerCli, repoName, fmt.Sprintf(`
+					FROM scratch
+					LABEL repo_name_for_randomisation=%s
+				`, repoName))
+			img, err = factory.NewLocal(repoName, false)
+			h.AssertNil(t, err)
+			origID = h.ImageID(t, repoName)
+		})
+
+		it.After(func() {
+			h.AssertNil(t, h.DockerRmi(dockerCli, repoName, origID))
+		})
+
+		it("sets the entrypoint", func() {
+			err := img.SetEntrypoint("some", "entrypoint")
+			h.AssertNil(t, err)
+
+			_, err = img.Save()
+			h.AssertNil(t, err)
+
+			inspect, _, err := dockerCli.ImageInspectWithRaw(context.TODO(), repoName)
+			h.AssertNil(t, err)
+
+			h.AssertEq(t, []string(inspect.Config.Entrypoint), []string{"some", "entrypoint"})
+		})
+	})
+
+	when("#SetCmd", func() {
+		var (
+			img    image.Image
+			origID string
+		)
+
+		it.Before(func() {
+			var err error
+			h.CreateImageOnLocal(t, dockerCli, repoName, fmt.Sprintf(`
+					FROM scratch
+					LABEL repo_name_for_randomisation=%s
+				`, repoName))
+			img, err = factory.NewLocal(repoName, false)
+			h.AssertNil(t, err)
+			origID = h.ImageID(t, repoName)
+		})
+
+		it.After(func() {
+			h.AssertNil(t, h.DockerRmi(dockerCli, repoName, origID))
+		})
+
+		it("sets the cmd", func() {
+			err := img.SetCmd("some", "cmd")
+			h.AssertNil(t, err)
+
+			_, err = img.Save()
+			h.AssertNil(t, err)
+
+			inspect, _, err := dockerCli.ImageInspectWithRaw(context.TODO(), repoName)
+			h.AssertNil(t, err)
+
+			h.AssertEq(t, []string(inspect.Config.Cmd), []string{"some", "cmd"})
+		})
+	})
+
 	when("#Rebase", func() {
 		when("image exists", func() {
 			var oldBase, oldTopLayer, newBase, origID string

--- a/image/remote.go
+++ b/image/remote.go
@@ -154,6 +154,28 @@ func (r *remote) SetEnv(key, val string) error {
 	return err
 }
 
+func (r *remote) SetEntrypoint(ep ...string) error {
+	configFile, err := r.Image.ConfigFile()
+	if err != nil {
+		return err
+	}
+	config := *configFile.Config.DeepCopy()
+	config.Entrypoint = ep
+	r.Image, err = mutate.Config(r.Image, config)
+	return err
+}
+
+func (r *remote) SetCmd(cmd ...string) error {
+	configFile, err := r.Image.ConfigFile()
+	if err != nil {
+		return err
+	}
+	config := *configFile.Config.DeepCopy()
+	config.Cmd = cmd
+	r.Image, err = mutate.Config(r.Image, config)
+	return err
+}
+
 func (r *remote) TopLayer() (string, error) {
 	all, err := r.Image.Layers()
 	if err != nil {

--- a/image/remote_test.go
+++ b/image/remote_test.go
@@ -216,6 +216,68 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
+	when("#SetEntrypoint", func() {
+		var (
+			img image.Image
+		)
+		it.Before(func() {
+			var err error
+			h.CreateImageOnRemote(t, dockerCli, repoName, fmt.Sprintf(`
+					FROM scratch
+					LABEL repo_name_for_randomisation=%s
+				`, repoName))
+			img, err = factory.NewRemote(repoName)
+			h.AssertNil(t, err)
+		})
+
+		it("sets the entrypoint", func() {
+			err := img.SetEntrypoint("some", "entrypoint")
+			h.AssertNil(t, err)
+
+			_, err = img.Save()
+			h.AssertNil(t, err)
+
+			h.AssertNil(t, h.PullImage(dockerCli, repoName))
+			defer h.DockerRmi(dockerCli, repoName)
+
+			inspect, _, err := dockerCli.ImageInspectWithRaw(context.TODO(), repoName)
+			h.AssertNil(t, err)
+
+			h.AssertEq(t, []string(inspect.Config.Entrypoint), []string{"some", "entrypoint"})
+		})
+	})
+
+	when("#SetCmd", func() {
+		var (
+			img image.Image
+		)
+		it.Before(func() {
+			var err error
+			h.CreateImageOnRemote(t, dockerCli, repoName, fmt.Sprintf(`
+					FROM scratch
+					LABEL repo_name_for_randomisation=%s
+				`, repoName))
+			img, err = factory.NewRemote(repoName)
+			h.AssertNil(t, err)
+		})
+
+		it("sets the cmd", func() {
+			err := img.SetCmd("some", "cmd")
+			h.AssertNil(t, err)
+
+			_, err = img.Save()
+			h.AssertNil(t, err)
+
+			h.AssertNil(t, h.PullImage(dockerCli, repoName))
+			defer h.DockerRmi(dockerCli, repoName)
+
+			inspect, _, err := dockerCli.ImageInspectWithRaw(context.TODO(), repoName)
+			h.AssertNil(t, err)
+
+			h.AssertEq(t, []string(inspect.Config.Cmd), []string{"some", "cmd"})
+		})
+	})
+
 	when("#Rebase", func() {
 		when("image exists", func() {
 			var oldBase, oldTopLayer, newBase string

--- a/metadata.go
+++ b/metadata.go
@@ -7,6 +7,7 @@ const (
 type AppImageMetadata struct {
 	App        AppMetadata         `json:"app"`
 	Config     ConfigMetadata      `json:"config"`
+	Launcher   LauncherMetadata    `json:"launcher"`
 	Buildpacks []BuildpackMetadata `json:"buildpacks"`
 	RunImage   RunImageMetadata    `json:"runImage"`
 }
@@ -16,6 +17,10 @@ type AppMetadata struct {
 }
 
 type ConfigMetadata struct {
+	SHA string `json:"sha"`
+}
+
+type LauncherMetadata struct {
 	SHA string `json:"sha"`
 }
 

--- a/testdata/exporter/launcher
+++ b/testdata/exporter/launcher
@@ -1,0 +1,1 @@
+some-launcher

--- a/testhelpers/test_image.go
+++ b/testhelpers/test_image.go
@@ -33,6 +33,8 @@ type FakeImage struct {
 	topLayerSha  string
 	digest       string
 	name         string
+	entryPoint   []string
+	cmd          []string
 }
 
 func (f *FakeImage) Label(key string) (string, error) {
@@ -68,8 +70,20 @@ func (f *FakeImage) SetEnv(k string, v string) error {
 	return nil
 }
 
-func (f *FakeImage) Env(key string) (string, error) {
-	return f.env[key], nil
+func (f *FakeImage) SetEntrypoint(v ...string) error {
+	f.assertNotAlreadySaved()
+	f.entryPoint = v
+	return nil
+}
+
+func (f *FakeImage) SetCmd(v ...string) error {
+	f.assertNotAlreadySaved()
+	f.cmd = v
+	return nil
+}
+
+func (f *FakeImage) Env(k string) (string, error) {
+	return f.env[k], nil
 }
 
 func (f *FakeImage) TopLayer() (string, error) {
@@ -100,10 +114,18 @@ func (FakeImage) Found() (bool, error) {
 	return true, nil
 }
 
-//test methods
-
 func (f *FakeImage) AppLayerPath() string {
 	return f.layers[0]
+}
+
+//test methods
+
+func (f *FakeImage) Entrypoint() ([]string, error) {
+	return f.entryPoint, nil
+}
+
+func (f *FakeImage) Cmd() ([]string, error) {
+	return f.cmd, nil
 }
 
 func (f *FakeImage) ConfigLayerPath() string {

--- a/testmock/image.go
+++ b/testmock/image.go
@@ -156,6 +156,38 @@ func (mr *MockImageMockRecorder) Save() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Save", reflect.TypeOf((*MockImage)(nil).Save))
 }
 
+// SetCmd mocks base method
+func (m *MockImage) SetCmd(arg0 ...string) error {
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "SetCmd", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetCmd indicates an expected call of SetCmd
+func (mr *MockImageMockRecorder) SetCmd(arg0 ...interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCmd", reflect.TypeOf((*MockImage)(nil).SetCmd), arg0...)
+}
+
+// SetEntrypoint mocks base method
+func (m *MockImage) SetEntrypoint(arg0 ...string) error {
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "SetEntrypoint", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetEntrypoint indicates an expected call of SetEntrypoint
+func (mr *MockImageMockRecorder) SetEntrypoint(arg0 ...interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEntrypoint", reflect.TypeOf((*MockImage)(nil).SetEntrypoint), arg0...)
+}
+
 // SetEnv mocks base method
 func (m *MockImage) SetEnv(arg0, arg1 string) error {
 	ret := m.ctrl.Call(m, "SetEnv", arg0, arg1)


### PR DESCRIPTION
* export launcher as a layer
* set the entrypoint to /lifecycle/launcher
* ensure no cmd

Signed-off-by: Emily Casey <ecasey@pivotal.io>