### PR TITLE
Improve logging of buildpack ID and layer names

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -56,25 +56,25 @@ func (a *Analyzer) analyze(metadata AppImageMetadata) error {
 			cacheType := cachedLayer.classifyCache(metadataLayers)
 			switch cacheType {
 			case cacheStaleNoMetadata:
-				a.Out.Printf("removing stale cached launch layer '%s/%s', not in metadata \n", buildpackID, cachedLayer)
+				a.Out.Printf("removing stale cached launch layer '%s:%s', not in metadata \n", buildpackID, cachedLayer)
 				if err := cachedLayer.remove(); err != nil {
 					return err
 				}
 			case cacheStaleWrongSHA:
-				a.Out.Printf("removing stale cached launch layer '%s/%s'", buildpackID, cachedLayer)
+				a.Out.Printf("removing stale cached launch layer '%s:%s'", buildpackID, cachedLayer)
 				if err := cachedLayer.remove(); err != nil {
 					return err
 				}
 			case cacheMalformed:
-				a.Out.Printf("removing malformed cached layer '%s/%s'", buildpackID, cachedLayer)
+				a.Out.Printf("removing malformed cached layer '%s:%s'", buildpackID, cachedLayer)
 				if err := cachedLayer.remove(); err != nil {
 					return err
 				}
 			case cacheNotForLaunch:
 				a.Out.Printf("using cached layer '%s/%s'", buildpackID, cachedLayer)
 			case cacheValid:
-				a.Out.Printf("using cached launch layer '%s/%s'", buildpackID, cachedLayer)
-				a.Out.Printf("rewriting metadata for layer '%s/%s'", buildpackID, cachedLayer)
+				a.Out.Printf("using cached launch layer '%s:%s'", buildpackID, cachedLayer)
+				a.Out.Printf("rewriting metadata for layer '%s:%s'", buildpackID, cachedLayer)
 				if err := cachedLayer.writeMetadata(metadataLayers); err != nil {
 					return err
 				}

--- a/exporter.go
+++ b/exporter.go
@@ -66,7 +66,7 @@ func (e *Exporter) Export(layersDir, appDir string, runImage, origImage image.Im
 	}
 
 	for _, bp := range e.Buildpacks {
-		bpDir, err := readBuildpackLayersDir(layersDir, bp.EscapedID())
+		bpDir, err := readBuildpackLayersDir(layersDir, bp.ID)
 		if err != nil {
 			return errors.Wrapf(err, "reading layers for buildpack '%s'", bp.ID)
 		}

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -163,7 +163,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeRunImage, fakeOriginalImage, launcherPath))
 
 				h.AssertContains(t, fakeRunImage.ReusedLayers(), "sha256:orig-launch-layer-no-local-dir-sha")
-				assertReuseLayerLog(t, stdout, "buildpack.id/launch-layer-no-local-dir", "orig-launch-layer-no-local-dir-sha")
+				assertReuseLayerLog(t, stdout, "buildpack.id:launch-layer-no-local-dir", "orig-launch-layer-no-local-dir-sha")
 			})
 
 			it("reuses cached launch layers if the local sha matches the sha in the metadata", func() {
@@ -172,7 +172,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeRunImage, fakeOriginalImage, launcherPath))
 
 				h.AssertContains(t, fakeRunImage.ReusedLayers(), "sha256:"+layer5sha)
-				assertReuseLayerLog(t, stdout, "other.buildpack.id/local-reusable-layer", layer5sha)
+				assertReuseLayerLog(t, stdout, "other.buildpack.id:local-reusable-layer", layer5sha)
 			})
 
 			it("adds new launch layers", func() {
@@ -185,7 +185,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 					filepath.Join(layersDir, "buildpack.id/new-launch-layer/file-from-new-launch-layer"),
 					"echo text from layer 2\n")
 				assertTarFileOwner(t, layer2Path, filepath.Join(layersDir, "buildpack.id/new-launch-layer"), uid, gid)
-				assertAddLayerLog(t, stdout, "buildpack.id/new-launch-layer", layer2Path)
+				assertAddLayerLog(t, stdout, "buildpack.id:new-launch-layer", layer2Path)
 			})
 
 			it("adds new launch layers from a second buildpack", func() {
@@ -198,7 +198,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 					filepath.Join(layersDir, "other.buildpack.id/new-launch-layer/new-launch-layer-file"),
 					"echo text from new layer\n")
 				assertTarFileOwner(t, layer3Path, filepath.Join(layersDir, "other.buildpack.id/new-launch-layer"), uid, gid)
-				assertAddLayerLog(t, stdout, "other.buildpack.id/new-launch-layer", layer3Path)
+				assertAddLayerLog(t, stdout, "other.buildpack.id:new-launch-layer", layer3Path)
 			})
 
 			it("only creates expected layers", func() {
@@ -324,7 +324,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 					h.AssertError(
 						t,
 						exporter.Export(layersDir, appDir, fakeRunImage, fakeOriginalImage, launcherPath),
-						"cannot reuse 'buildpack.id/launch-layer-no-local-dir', previous image has no metadata for layer 'buildpack.id/launch-layer-no-local-dir'",
+						"cannot reuse 'buildpack.id:launch-layer-no-local-dir', previous image has no metadata for layer 'buildpack.id:launch-layer-no-local-dir'",
 					)
 				})
 			})
@@ -340,7 +340,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 					h.AssertError(
 						t,
 						exporter.Export(layersDir, appDir, fakeRunImage, fakeOriginalImage, launcherPath),
-						"cannot reuse 'buildpack.id/launch-layer-no-local-dir', previous image has no metadata for layer 'buildpack.id/launch-layer-no-local-dir'",
+						"cannot reuse 'buildpack.id:launch-layer-no-local-dir', previous image has no metadata for layer 'buildpack.id:launch-layer-no-local-dir'",
 					)
 				})
 			})
@@ -412,7 +412,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 					filepath.Join(layersDir, "buildpack.id/layer1/file-from-layer-1"),
 					"echo text from layer 1\n")
 				assertTarFileOwner(t, layer1Path, filepath.Join(layersDir, "buildpack.id/layer1"), uid, gid)
-				assertAddLayerLog(t, stdout, "buildpack.id/layer1", layer1Path)
+				assertAddLayerLog(t, stdout, "buildpack.id:layer1", layer1Path)
 
 				layer2Path := fakeRunImage.FindLayerWithPath(filepath.Join(layersDir, "buildpack.id/layer2"))
 				assertTarFileContents(t,
@@ -420,7 +420,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 					filepath.Join(layersDir, "buildpack.id/layer2/file-from-layer-2"),
 					"echo text from layer 2\n")
 				assertTarFileOwner(t, layer2Path, filepath.Join(layersDir, "buildpack.id/layer2"), uid, gid)
-				assertAddLayerLog(t, stdout, "buildpack.id/layer2", layer2Path)
+				assertAddLayerLog(t, stdout, "buildpack.id:layer2", layer2Path)
 			})
 
 			it("only creates expected layers", func() {
@@ -621,7 +621,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 					filepath.Join(layersDir, "some_escaped_bp_id/some-layer/some-file"),
 					"some-file-contents\n")
 				assertTarFileOwner(t, layerPath, filepath.Join(layersDir, "some_escaped_bp_id/some-layer/some-file"), uid, gid)
-				assertAddLayerLog(t, stdout, "some_escaped_bp_id/some-layer", layerPath)
+				assertAddLayerLog(t, stdout, "some/escaped/bp/id:some-layer", layerPath)
 			})
 
 			it("exports buildpack metadata with unescaped id", func() {
@@ -644,7 +644,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 
 func assertAddLayerLog(t *testing.T, stdout bytes.Buffer, name, layerPath string) {
 	t.Helper()
-	layerSHA := h.ComputeSHA256ForFile(t, layerPath)
+	layerSHA := h.ComputeSHA256ForFile(t, strings.Replace(layerPath, ":", "/", -1))
 
 	expected := fmt.Sprintf("adding layer '%s' with diffID 'sha256:%s'", name, layerSHA)
 	if !strings.Contains(stdout.String(), expected) {

--- a/layers.go
+++ b/layers.go
@@ -17,7 +17,7 @@ type bpLayersDir struct {
 }
 
 func readBuildpackLayersDir(layersDir, buildpackID string) (bpLayersDir, error) {
-	path := filepath.Join(layersDir, buildpackID)
+	path := filepath.Join(layersDir, BuildpackIdToDir(buildpackID))
 	tomls, err := filepath.Glob(filepath.Join(path, "*.toml"))
 	if err != nil {
 		return bpLayersDir{}, err
@@ -27,8 +27,8 @@ func readBuildpackLayersDir(layersDir, buildpackID string) (bpLayersDir, error) 
 		name := strings.TrimRight(filepath.Base(toml), ".toml")
 		layers = append(layers, bpLayer{
 			layer{
-				path:       filepath.Join(layersDir, buildpackID, name),
-				identifier: fmt.Sprintf("%s/%s", buildpackID, name),
+				path:       filepath.Join(layersDir, BuildpackIdToDir(buildpackID), name),
+				identifier: fmt.Sprintf("%s:%s", buildpackID, name),
 			},
 		})
 	}
@@ -61,8 +61,8 @@ func (bd *bpLayersDir) findLayers(f func(layer LayerMetadata) bool) []bpLayer {
 func (bd *bpLayersDir) newBPLayer(name string) *bpLayer {
 	return &bpLayer{
 		layer{
-			path:       filepath.Join(bd.path, name),
-			identifier: fmt.Sprintf("%s/%s", bd.name, name),
+			path:       filepath.Join(bd.path, BuildpackIdToDir(name)),
+			identifier: fmt.Sprintf("%s:%s", bd.name, name),
 		},
 	}
 }


### PR DESCRIPTION
This changes all logging to use a `:` instead of a `/` to separate buildpack ID from layer name. This important because `/` is a valid buildpack ID character.

It also prevents the logging of escaped buildpack IDs, which won't mean anything to a user, who should only ever see the real buildpack ID.

Both of these prevent the implementation detail that buildpacks and layers are directories from bleeding through.