### PR TITLE
Allow multiple image Authentication Headers to be passed to lifecycle

### DIFF
--- a/cmd/analyzer/main.go
+++ b/cmd/analyzer/main.go
@@ -60,7 +60,7 @@ func analyzer() error {
 
 	var err error
 	var previousImage image.Image
-	factory, err := image.DefaultFactory()
+	factory, err := image.NewFactory(image.WithEnvKeychain, image.WithLegacyEnvKeychain)
 	if err != nil {
 		return err
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -20,12 +20,13 @@ const (
 	DefaultUseDaemon      = false
 	DefaultUseCredHelpers = false
 
-	EnvRunImage     = "PACK_RUN_IMAGE"
-	EnvUID          = "PACK_USER_ID"
-	EnvGID          = "PACK_GROUP_ID"
-	EnvLayersDir    = "PACK_LAYERS_DIR"
-	EnvAppDir       = "PACK_APP_DIR"
-	EnvRegistryAuth = "PACK_REGISTRY_AUTH"
+	EnvRunImage           = "PACK_RUN_IMAGE"
+	EnvUID                = "PACK_USER_ID"
+	EnvGID                = "PACK_GROUP_ID"
+	EnvLayersDir          = "PACK_LAYERS_DIR"
+	EnvAppDir             = "PACK_APP_DIR"
+	EnvLegacyRegistryAuth = "PACK_REGISTRY_AUTH"
+	EnvRegistryAuth       = "CNB_REGISTRY_AUTH"
 )
 
 func FlagLayersDir(dir *string) {

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -75,7 +75,7 @@ func export() error {
 		ArtifactsDir: artifactsDir,
 	}
 
-	factory, err := image.DefaultFactory()
+	factory, err := image.NewFactory(image.WithEnvKeychain, image.WithLegacyEnvKeychain)
 	if err != nil {
 		return err
 	}

--- a/image/auth/env_keychain.go
+++ b/image/auth/env_keychain.go
@@ -1,0 +1,64 @@
+package auth
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/pkg/errors"
+
+	"github.com/buildpack/lifecycle/cmd"
+)
+
+type EnvKeychain struct{}
+
+func (EnvKeychain) Resolve(registry name.Registry) (authn.Authenticator, error) {
+	env := os.Getenv(cmd.EnvRegistryAuth)
+	if env == "" {
+		return authn.Anonymous, nil
+	}
+	authMap := map[string]string{}
+	err := json.Unmarshal([]byte(env), &authMap)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse %s value", cmd.EnvRegistryAuth)
+	}
+	auth, ok := authMap[registry.Name()]
+	if ok {
+		return &providedAuth{auth: auth}, nil
+	}
+
+	return authn.Anonymous, nil
+}
+
+type providedAuth struct {
+	auth string
+}
+
+func (p *providedAuth) Authorization() (string, error) {
+	return p.auth, nil
+}
+
+func BuildEnvVar(keychain authn.Keychain, images ...string) (string, error) {
+	registryAuths := map[string]string{}
+
+	for _, image := range images {
+		reference, authenticator, err := ReferenceForRepoName(keychain, image)
+		if err != nil {
+			return "", nil
+		}
+		if authenticator == authn.Anonymous {
+			continue
+		}
+
+		registryAuths[reference.Context().Registry.Name()], err = authenticator.Authorization()
+		if err != nil {
+			return "", nil
+		}
+	}
+	authData, err := json.Marshal(registryAuths)
+	if err != nil {
+		return "", err
+	}
+	return string(authData), nil
+}

--- a/image/auth/env_keychain_test.go
+++ b/image/auth/env_keychain_test.go
@@ -1,0 +1,145 @@
+package auth_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	"github.com/buildpack/lifecycle/image/auth"
+	h "github.com/buildpack/lifecycle/testhelpers"
+)
+
+func TestEnvKeychain(t *testing.T) {
+	spec.Run(t, "Env Keychain", testEnvKeychain, spec.Sequential(), spec.Report(report.Terminal{}))
+}
+
+func testEnvKeychain(t *testing.T, when spec.G, it spec.S) {
+	when("EnvKeychain", func() {
+		var envKeyChain authn.Keychain
+
+		it.Before(func() {
+			envKeyChain = &auth.EnvKeychain{}
+		})
+
+		it.After(func() {
+			err := os.Unsetenv("CNB_REGISTRY_AUTH")
+			h.AssertNil(t, err)
+		})
+
+		when("#Resolve", func() {
+			when("valid auth env variable is set", func() {
+				it.Before(func() {
+					err := os.Setenv("CNB_REGISTRY_AUTH", "{\"some-registry.com\": \"some-auth-header\"}")
+					h.AssertNil(t, err)
+				})
+
+				it("loads the auth from the environment", func() {
+					registry, err := name.NewRegistry("some-registry.com", name.WeakValidation)
+					h.AssertNil(t, err)
+
+					auth, err := envKeyChain.Resolve(registry)
+					h.AssertNil(t, err)
+
+					header, err := auth.Authorization()
+					h.AssertNil(t, err)
+
+					h.AssertEq(t, header, "some-auth-header")
+				})
+
+				it("returns an Anonymous authenticator when the environment does not have a auth header", func() {
+					registry, err := name.NewRegistry("no-env-auth-registry.com", name.WeakValidation)
+					h.AssertNil(t, err)
+
+					auth, err := envKeyChain.Resolve(registry)
+					h.AssertNil(t, err)
+
+					h.AssertEq(t, auth, authn.Anonymous)
+				})
+			})
+
+			when("invalid env var is set", func() {
+				it.Before(func() {
+					err := os.Setenv("CNB_REGISTRY_AUTH", "NOT -- JSON")
+					h.AssertNil(t, err)
+				})
+
+				it("returns an error", func() {
+					registry, err := name.NewRegistry("some-registry.com", name.WeakValidation)
+					h.AssertNil(t, err)
+
+					_, err = envKeyChain.Resolve(registry)
+					h.AssertError(t, err, "failed to parse CNB_REGISTRY_AUTH value")
+				})
+			})
+
+			when("env var is not set", func() {
+				it("returns an Anonymous authenticator", func() {
+					registry, err := name.NewRegistry("no-env-auth-registry.com", name.WeakValidation)
+					h.AssertNil(t, err)
+
+					auth, err := envKeyChain.Resolve(registry)
+					h.AssertNil(t, err)
+
+					h.AssertEq(t, auth, authn.Anonymous)
+				})
+			})
+		})
+	})
+
+	when("#BuildAuthEnvVar", func() {
+		var keychain authn.Keychain
+
+		it.Before(func() {
+			keychain = &FakeKeychain{
+				auths: map[string]string{
+					"some-registry.com":  "some-registry.com-auth",
+					"other-registry.com": "other-registry.com-auth",
+					"index.docker.io":    "dockerhub-auth",
+				},
+			}
+		})
+
+		it("builds json encoded env with auth headers", func() {
+			envVar, err := auth.BuildEnvVar(keychain,
+				"some-registry.com/image",
+				"some-registry.com/image2",
+				"other-registry.com/image3",
+				"my/image")
+			h.AssertNil(t, err)
+
+			h.AssertEq(t, envVar, "{\"index.docker.io\":\"dockerhub-auth\",\"other-registry.com\":\"other-registry.com-auth\",\"some-registry.com\":\"some-registry.com-auth\"}")
+		})
+
+		it("returns an empty result for Anonymous registries", func() {
+			envVar, err := auth.BuildEnvVar(keychain, "anonymous.com/dockerhub/image")
+			h.AssertNil(t, err)
+
+			h.AssertEq(t, envVar, "{}")
+		})
+	})
+}
+
+type FakeKeychain struct {
+	auths map[string]string
+}
+
+func (f *FakeKeychain) Resolve(r name.Registry) (authn.Authenticator, error) {
+	key, ok := f.auths[r.Name()]
+	if ok {
+		return &providedAuth{auth: key}, nil
+	}
+
+	return authn.Anonymous, nil
+}
+
+type providedAuth struct {
+	auth string
+}
+
+func (p *providedAuth) Authorization() (string, error) {
+	return p.auth, nil
+}

--- a/image/auth/legacy_env_keychain.go
+++ b/image/auth/legacy_env_keychain.go
@@ -1,0 +1,20 @@
+package auth
+
+import (
+	"os"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+
+	"github.com/buildpack/lifecycle/cmd"
+)
+
+type LegacyEnvKeychain struct{}
+
+func (LegacyEnvKeychain) Resolve(name.Registry) (authn.Authenticator, error) {
+	env := os.Getenv(cmd.EnvLegacyRegistryAuth)
+	if env == "" {
+		return authn.Anonymous, nil
+	}
+	return &providedAuth{auth: env}, nil
+}

--- a/image/auth/legacy_env_keychain_test.go
+++ b/image/auth/legacy_env_keychain_test.go
@@ -1,0 +1,67 @@
+package auth_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	"github.com/buildpack/lifecycle/image/auth"
+	h "github.com/buildpack/lifecycle/testhelpers"
+)
+
+func TestLegacyEnvKeychain(t *testing.T) {
+	spec.Run(t, "Legacy Env Keychain", testLegacyEnvKeychain, spec.Sequential(), spec.Report(report.Terminal{}))
+}
+
+func testLegacyEnvKeychain(t *testing.T, when spec.G, it spec.S) {
+	when("LegacyEnvKeychain", func() {
+		var legacyEnvKeyChain authn.Keychain
+
+		it.Before(func() {
+			legacyEnvKeyChain = &auth.LegacyEnvKeychain{}
+		})
+
+		it.After(func() {
+			err := os.Unsetenv("PACK_REGISTRY_AUTH")
+			h.AssertNil(t, err)
+		})
+
+		when("#Resolve", func() {
+			when("valid auth env variable is set", func() {
+				it.Before(func() {
+					err := os.Setenv("PACK_REGISTRY_AUTH", "some-auth-header")
+					h.AssertNil(t, err)
+				})
+
+				it("loads the auth from the environment", func() {
+					registry, err := name.NewRegistry("some-registry.com", name.WeakValidation)
+					h.AssertNil(t, err)
+
+					auth, err := legacyEnvKeyChain.Resolve(registry)
+					h.AssertNil(t, err)
+
+					header, err := auth.Authorization()
+					h.AssertNil(t, err)
+
+					h.AssertEq(t, header, "some-auth-header")
+				})
+			})
+
+			when("env var is not set", func() {
+				it("returns an Anonymous authenticator", func() {
+					registry, err := name.NewRegistry("no-env-auth-registry.com", name.WeakValidation)
+					h.AssertNil(t, err)
+
+					auth, err := legacyEnvKeyChain.Resolve(registry)
+					h.AssertNil(t, err)
+
+					h.AssertEq(t, auth, authn.Anonymous)
+				})
+			})
+		})
+	})
+}

--- a/image/auth/reference.go
+++ b/image/auth/reference.go
@@ -1,0 +1,20 @@
+package auth
+
+import (
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+func ReferenceForRepoName(keychain authn.Keychain, ref string) (name.Reference, authn.Authenticator, error) {
+	var auth authn.Authenticator
+	r, err := name.ParseReference(ref, name.WeakValidation)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	auth, err = keychain.Resolve(r.Context().Registry)
+	if err != nil {
+		return nil, nil, err
+	}
+	return r, auth, nil
+}

--- a/image/local_test.go
+++ b/image/local_test.go
@@ -18,6 +18,7 @@ import (
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	dockerClient "github.com/docker/docker/client"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 
@@ -42,8 +43,9 @@ func testLocal(t *testing.T, when spec.G, it spec.S) {
 		dockerCli = h.DockerCli(t)
 		h.AssertNil(t, err)
 		factory = image.Factory{
-			Docker: dockerCli,
-			FS:     &fs.FS{},
+			Docker:   dockerCli,
+			FS:       &fs.FS{},
+			Keychain: authn.DefaultKeychain,
 		}
 		repoName = "pack-image-test-" + h.RandString(10)
 	})

--- a/image/remote_test.go
+++ b/image/remote_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	dockerClient "github.com/docker/docker/client"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 
@@ -48,8 +49,9 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 		dockerCli = h.DockerCli(t)
 		h.AssertNil(t, err)
 		factory = image.Factory{
-			Docker: dockerCli,
-			FS:     &fs.FS{},
+			Docker:   dockerCli,
+			FS:       &fs.FS{},
+			Keychain: authn.DefaultKeychain,
 		}
 		repoName = "localhost:" + registryPort + "/pack-image-test-" + h.RandString(10)
 	})


### PR DESCRIPTION
* CNB_REGISTRY_AUTH provides a json map of registry to auth header
* PACK_REGISTRY_AUTH provides a single auth header (deprecated)

[buildpack/roadmap#42]

Signed-off-by: Emily Casey <ecasey@pivotal.io>
Signed-off-by: Matthew McNew <mmcnew@pivotal.io>