### PR TITLE
When tests run as root, test that restorer chown layers dir

### DIFF
--- a/image/local.go
+++ b/image/local.go
@@ -69,10 +69,10 @@ func (f *Factory) NewEmptyLocal(repoName string) Image {
 		Labels: map[string]string{},
 	}
 	return &local{
-		RepoName:   repoName,
-		Docker:     f.Docker,
-		Inspect:    inspect,
-		prevOnce:   &sync.Once{},
+		RepoName: repoName,
+		Docker:   f.Docker,
+		Inspect:  inspect,
+		prevOnce: &sync.Once{},
 	}
 }
 

--- a/restorer.go
+++ b/restorer.go
@@ -52,11 +52,11 @@ func (r *Restorer) Restore(cacheImage image.Image) error {
 	} else if current == 0 {
 		uid, err := strconv.Atoi(os.Getenv(cmd.EnvUID))
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "failed to convert PACK_USER_ID '%s' to int", os.Getenv(cmd.EnvUID))
 		}
 		gid, err := strconv.Atoi(os.Getenv(cmd.EnvGID))
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "failed to convert PACK_GROUP_ID '%s' to int", os.Getenv(cmd.EnvGID))
 		}
 		if err := recursiveChown(r.LayersDir, uid, gid); err != nil {
 			return errors.Wrapf(err, "chowning layers dir to PACK_UID/PACK_GID '%d/%d'", uid, gid)


### PR DESCRIPTION
Signed-off-by: Emily Casey <ecasey@pivotal.io>

The lifecycle unit tests on ci.buildpacks.io run as root. These changes are needed so that they pass. We also test that layers dir user and group are correctly set in this case.