### PR TITLE
Lifecycle only gets remote or local image, without concern for pulling

### DIFF
--- a/cmd/analyzer/main.go
+++ b/cmd/analyzer/main.go
@@ -66,7 +66,7 @@ func analyzer() error {
 	}
 
 	if useDaemon {
-		previousImage, err = factory.NewLocal(repoName, false)
+		previousImage, err = factory.NewLocal(repoName)
 		if err != nil {
 			return err
 		}

--- a/cmd/cacher/main.go
+++ b/cmd/cacher/main.go
@@ -67,7 +67,7 @@ func cache() error {
 		return err
 	}
 
-	origCacheImage, err := factory.NewLocal(cacheImageTag, false)
+	origCacheImage, err := factory.NewLocal(cacheImageTag)
 	if err != nil {
 		return err
 	}

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -85,11 +85,11 @@ func export() error {
 	}
 	var runImage, origImage image.Image
 	if useDaemon {
-		runImage, err = factory.NewLocal(runImageRef, false)
+		runImage, err = factory.NewLocal(runImageRef)
 		if err != nil {
 			return err
 		}
-		origImage, err = factory.NewLocal(repoName, false)
+		origImage, err = factory.NewLocal(repoName)
 		if err != nil {
 			return err
 		}

--- a/cmd/restorer/main.go
+++ b/cmd/restorer/main.go
@@ -55,7 +55,7 @@ func restore() error {
 		return err
 	}
 
-	cacheImage, err := factory.NewLocal(cacheImageTag, false)
+	cacheImage, err := factory.NewLocal(cacheImageTag)
 	if err != nil {
 		return err
 	}

--- a/image/local.go
+++ b/image/local.go
@@ -107,8 +107,10 @@ func (l *local) Found() (bool, error) {
 }
 
 func (l *local) Digest() (string, error) {
-	if found, _ := l.Found(); !found {
-		return "", fmt.Errorf("failed to get digest, image '%s' does n1ot exist", l.RepoName)
+	if found, err := l.Found(); err != nil {
+		return "", errors.Wrap(err, "determining image existence")
+	} else if !found {
+		return "", fmt.Errorf("failed to get digest, image '%s' does not exist", l.RepoName)
 	}
 	if len(l.Inspect.RepoDigests) == 0 {
 		return "", nil

--- a/image/local_test.go
+++ b/image/local_test.go
@@ -210,7 +210,7 @@ func testLocal(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("returns the image digest", func() {
-				img, err := factory.NewLocal("busybox@sha256:2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812")
+				img, err := factory.NewRemote("busybox@sha256:2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812")
 				h.AssertNil(t, err)
 				digest, err := img.Digest()
 				h.AssertNil(t, err)

--- a/image/local_test.go
+++ b/image/local_test.go
@@ -111,7 +111,7 @@ func testLocal(t *testing.T, when spec.G, it spec.S) {
 					FROM scratch
 					LABEL repo_name_for_randomisation=%s
 					LABEL mykey=myvalue other=data
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 			})
 
 			it.After(func() {
@@ -155,7 +155,7 @@ func testLocal(t *testing.T, when spec.G, it spec.S) {
 					FROM scratch
 					LABEL repo_name_for_randomisation=%s
 					ENV MY_VAR=my_val
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 			})
 
 			it.After(func() {
@@ -224,7 +224,7 @@ func testLocal(t *testing.T, when spec.G, it spec.S) {
 					FROM scratch
 					LABEL repo_name_for_randomisation=%s
 					LABEL key=val
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 			})
 
 			it.After(func() {
@@ -253,7 +253,7 @@ func testLocal(t *testing.T, when spec.G, it spec.S) {
 					FROM scratch
 					LABEL repo_name_for_randomisation=%s
 					LABEL some-key=some-value
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 				img, err = factory.NewLocal(repoName)
 				h.AssertNil(t, err)
 				origID = h.ImageID(t, repoName)
@@ -292,7 +292,7 @@ func testLocal(t *testing.T, when spec.G, it spec.S) {
 					FROM scratch
 					LABEL repo_name_for_randomisation=%s
 					LABEL some-key=some-value
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 			img, err = factory.NewLocal(repoName)
 			h.AssertNil(t, err)
 			origID = h.ImageID(t, repoName)
@@ -326,7 +326,7 @@ func testLocal(t *testing.T, when spec.G, it spec.S) {
 			h.CreateImageOnLocal(t, dockerCli, repoName, fmt.Sprintf(`
 					FROM scratch
 					LABEL repo_name_for_randomisation=%s
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 			img, err = factory.NewLocal(repoName)
 			h.AssertNil(t, err)
 			origID = h.ImageID(t, repoName)
@@ -361,7 +361,7 @@ func testLocal(t *testing.T, when spec.G, it spec.S) {
 			h.CreateImageOnLocal(t, dockerCli, repoName, fmt.Sprintf(`
 					FROM scratch
 					LABEL repo_name_for_randomisation=%s
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 			img, err = factory.NewLocal(repoName)
 			h.AssertNil(t, err)
 			origID = h.ImageID(t, repoName)
@@ -400,7 +400,7 @@ func testLocal(t *testing.T, when spec.G, it spec.S) {
 						LABEL repo_name_for_randomisation=%s
 						RUN echo new-base > base.txt
 						RUN echo text-new-base > otherfile.txt
-					`, newBase), make(map[string]string))
+					`, newBase), nil)
 				}()
 
 				oldBase = "pack-oldbase-test-" + h.RandString(10)
@@ -409,7 +409,7 @@ func testLocal(t *testing.T, when spec.G, it spec.S) {
 					LABEL repo_name_for_randomisation=%s
 					RUN echo old-base > base.txt
 					RUN echo text-old-base > otherfile.txt
-				`, oldBase), make(map[string]string))
+				`, oldBase), nil)
 				inspect, _, err := dockerCli.ImageInspectWithRaw(context.TODO(), oldBase)
 				h.AssertNil(t, err)
 				oldTopLayer = inspect.RootFS.Layers[len(inspect.RootFS.Layers)-1]
@@ -419,7 +419,7 @@ func testLocal(t *testing.T, when spec.G, it spec.S) {
 					LABEL repo_name_for_randomisation=%s
 					RUN echo text-from-image > myimage.txt
 					RUN echo text-from-image > myimage2.txt
-				`, oldBase, repoName), make(map[string]string))
+				`, oldBase, repoName), nil)
 				inspect, _, err = dockerCli.ImageInspectWithRaw(context.TODO(), repoName)
 				h.AssertNil(t, err)
 				origNumLayers = len(inspect.RootFS.Layers)
@@ -481,7 +481,7 @@ func testLocal(t *testing.T, when spec.G, it spec.S) {
 				LABEL repo_name_for_randomisation=%s
 				RUN echo old-base > base.txt
 				RUN echo text-old-base > otherfile.txt
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 
 				inspect, _, err := dockerCli.ImageInspectWithRaw(context.TODO(), repoName)
 				h.AssertNil(t, err)
@@ -515,7 +515,7 @@ func testLocal(t *testing.T, when spec.G, it spec.S) {
 					FROM busybox
 					LABEL repo_name_for_randomisation=%s
 					RUN echo -n old-layer > old-layer.txt
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 			tr, err := h.CreateSingleFileTar("/new-layer.txt", "new-layer")
 			h.AssertNil(t, err)
 			tarFile, err := ioutil.TempFile("", "add-layer-test")
@@ -560,7 +560,7 @@ func testLocal(t *testing.T, when spec.G, it spec.S) {
 					FROM busybox
 					LABEL repo_name_for_randomisation=%s
 					RUN mkdir /dir && echo -n file-contents > /dir/file.txt
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 			})
 
 			it("returns a layer tar", func() {
@@ -591,7 +591,7 @@ func testLocal(t *testing.T, when spec.G, it spec.S) {
 				h.CreateImageOnLocal(t, dockerCli, repoName, fmt.Sprintf(`
 					FROM busybox
 					LABEL repo_name_for_randomisation=%s
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 			})
 
 			it("returns an error", func() {
@@ -622,7 +622,7 @@ func testLocal(t *testing.T, when spec.G, it spec.S) {
 					LABEL repo_name_for_randomisation=%s
 					RUN echo -n old-layer-1 > layer-1.txt
 					RUN echo -n old-layer-2 > layer-2.txt
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 
 			inspect, _, err := dockerCli.ImageInspectWithRaw(context.TODO(), repoName)
 			h.AssertNil(t, err)
@@ -687,7 +687,7 @@ func testLocal(t *testing.T, when spec.G, it spec.S) {
 					FROM busybox
 					LABEL repo_name_for_randomisation=%s
 					LABEL mykey=oldValue
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 				img, err = factory.NewLocal(repoName)
 				h.AssertNil(t, err)
 				origID = h.ImageID(t, repoName)
@@ -718,7 +718,7 @@ func testLocal(t *testing.T, when spec.G, it spec.S) {
 				h.CreateImageOnLocal(t, dockerCli, repoName, fmt.Sprintf(`
 					FROM scratch
 					LABEL repo_name_for_randomisation=%s
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 			})
 
 			it.After(func() {

--- a/image/remote_test.go
+++ b/image/remote_test.go
@@ -62,7 +62,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 					FROM scratch
 					LABEL repo_name_for_randomisation=%s
 					LABEL mykey=myvalue other=data
-				`, repoName))
+				`, repoName), make(map[string]string))
 
 				var err error
 				img, err = factory.NewRemote(repoName)
@@ -100,7 +100,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 					FROM scratch
 					LABEL repo_name_for_randomisation=%s
 					ENV MY_VAR=my_val
-				`, repoName))
+				`, repoName), make(map[string]string))
 			})
 
 			it("returns the label value", func() {
@@ -161,7 +161,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 					FROM scratch
 					LABEL repo_name_for_randomisation=%s
 					LABEL mykey=myvalue other=data
-				`, repoName))
+				`, repoName), make(map[string]string))
 
 				var err error
 				img, err = factory.NewRemote(repoName)
@@ -197,7 +197,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 					FROM scratch
 					LABEL repo_name_for_randomisation=%s
 					LABEL some-key=some-value
-				`, repoName))
+				`, repoName), make(map[string]string))
 			img, err = factory.NewRemote(repoName)
 			h.AssertNil(t, err)
 		})
@@ -228,7 +228,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 			h.CreateImageOnRemote(t, dockerCli, repoName, fmt.Sprintf(`
 					FROM scratch
 					LABEL repo_name_for_randomisation=%s
-				`, repoName))
+				`, repoName), make(map[string]string))
 			img, err = factory.NewRemote(repoName)
 			h.AssertNil(t, err)
 		})
@@ -259,7 +259,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 			h.CreateImageOnRemote(t, dockerCli, repoName, fmt.Sprintf(`
 					FROM scratch
 					LABEL repo_name_for_randomisation=%s
-				`, repoName))
+				`, repoName), make(map[string]string))
 			img, err = factory.NewRemote(repoName)
 			h.AssertNil(t, err)
 		})
@@ -297,7 +297,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 						LABEL repo_name_for_randomisation=%s
 						RUN echo new-base > base.txt
 						RUN echo text-new-base > otherfile.txt
-					`, repoName))
+					`, repoName), make(map[string]string))
 					newBaseLayers = manifestLayers(t, newBase)
 				}()
 
@@ -307,7 +307,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 					LABEL repo_name_for_randomisation=%s
 					RUN echo old-base > base.txt
 					RUN echo text-old-base > otherfile.txt
-				`, oldBase))
+				`, oldBase), make(map[string]string))
 				oldBaseLayers = manifestLayers(t, oldBase)
 
 				h.CreateImageOnRemote(t, dockerCli, repoName, fmt.Sprintf(`
@@ -315,7 +315,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 					LABEL repo_name_for_randomisation=%s
 					RUN echo text-from-image-1 > myimage.txt
 					RUN echo text-from-image-2 > myimage2.txt
-				`, oldBase, repoName))
+				`, oldBase, repoName), make(map[string]string))
 				repoTopLayers = manifestLayers(t, repoName)[len(oldBaseLayers):]
 
 				wg.Wait()
@@ -359,7 +359,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 					LABEL repo_name_for_randomisation=%s
 					RUN echo old-base > base.txt
 					RUN echo text-old-base > otherfile.txt
-				`, repoName))
+				`, repoName), make(map[string]string))
 
 				img, err := factory.NewRemote(repoName)
 				h.AssertNil(t, err)
@@ -382,7 +382,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 					FROM busybox
 					LABEL repo_name_for_randomisation=%s
 					RUN echo -n old-layer > old-layer.txt
-				`, repoName))
+				`, repoName), make(map[string]string))
 			tr, err := h.CreateSingleFileTar("/new-layer.txt", "new-layer")
 			h.AssertNil(t, err)
 			tarFile, err := ioutil.TempFile("", "add-layer-test")
@@ -436,7 +436,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 					LABEL repo_name_for_randomisation=%s
 					RUN echo -n old-layer-1 > layer-1.txt
 					RUN echo -n old-layer-2 > layer-2.txt
-				`, repoName))
+				`, repoName), make(map[string]string))
 
 				h.AssertNil(t, h.PullImage(dockerCli, repoName))
 				defer func() {
@@ -496,7 +496,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 					FROM busybox
 					LABEL repo_name_for_randomisation=%s
 					LABEL mykey=oldValue
-				`, repoName))
+				`, repoName), make(map[string]string))
 			})
 
 			it("returns the image digest", func() {
@@ -551,7 +551,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 				h.CreateImageOnRemote(t, dockerCli, repoName, fmt.Sprintf(`
 					FROM scratch
 					LABEL repo_name_for_randomisation=%s
-				`, repoName))
+				`, repoName), make(map[string]string))
 			})
 
 			it("returns true, nil", func() {

--- a/image/remote_test.go
+++ b/image/remote_test.go
@@ -62,7 +62,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 					FROM scratch
 					LABEL repo_name_for_randomisation=%s
 					LABEL mykey=myvalue other=data
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 
 				var err error
 				img, err = factory.NewRemote(repoName)
@@ -100,7 +100,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 					FROM scratch
 					LABEL repo_name_for_randomisation=%s
 					ENV MY_VAR=my_val
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 			})
 
 			it("returns the label value", func() {
@@ -161,7 +161,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 					FROM scratch
 					LABEL repo_name_for_randomisation=%s
 					LABEL mykey=myvalue other=data
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 
 				var err error
 				img, err = factory.NewRemote(repoName)
@@ -197,7 +197,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 					FROM scratch
 					LABEL repo_name_for_randomisation=%s
 					LABEL some-key=some-value
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 			img, err = factory.NewRemote(repoName)
 			h.AssertNil(t, err)
 		})
@@ -228,7 +228,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 			h.CreateImageOnRemote(t, dockerCli, repoName, fmt.Sprintf(`
 					FROM scratch
 					LABEL repo_name_for_randomisation=%s
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 			img, err = factory.NewRemote(repoName)
 			h.AssertNil(t, err)
 		})
@@ -259,7 +259,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 			h.CreateImageOnRemote(t, dockerCli, repoName, fmt.Sprintf(`
 					FROM scratch
 					LABEL repo_name_for_randomisation=%s
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 			img, err = factory.NewRemote(repoName)
 			h.AssertNil(t, err)
 		})
@@ -297,7 +297,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 						LABEL repo_name_for_randomisation=%s
 						RUN echo new-base > base.txt
 						RUN echo text-new-base > otherfile.txt
-					`, repoName), make(map[string]string))
+					`, repoName), nil)
 					newBaseLayers = manifestLayers(t, newBase)
 				}()
 
@@ -307,7 +307,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 					LABEL repo_name_for_randomisation=%s
 					RUN echo old-base > base.txt
 					RUN echo text-old-base > otherfile.txt
-				`, oldBase), make(map[string]string))
+				`, oldBase), nil)
 				oldBaseLayers = manifestLayers(t, oldBase)
 
 				h.CreateImageOnRemote(t, dockerCli, repoName, fmt.Sprintf(`
@@ -315,7 +315,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 					LABEL repo_name_for_randomisation=%s
 					RUN echo text-from-image-1 > myimage.txt
 					RUN echo text-from-image-2 > myimage2.txt
-				`, oldBase, repoName), make(map[string]string))
+				`, oldBase, repoName), nil)
 				repoTopLayers = manifestLayers(t, repoName)[len(oldBaseLayers):]
 
 				wg.Wait()
@@ -359,7 +359,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 					LABEL repo_name_for_randomisation=%s
 					RUN echo old-base > base.txt
 					RUN echo text-old-base > otherfile.txt
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 
 				img, err := factory.NewRemote(repoName)
 				h.AssertNil(t, err)
@@ -382,7 +382,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 					FROM busybox
 					LABEL repo_name_for_randomisation=%s
 					RUN echo -n old-layer > old-layer.txt
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 			tr, err := h.CreateSingleFileTar("/new-layer.txt", "new-layer")
 			h.AssertNil(t, err)
 			tarFile, err := ioutil.TempFile("", "add-layer-test")
@@ -436,7 +436,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 					LABEL repo_name_for_randomisation=%s
 					RUN echo -n old-layer-1 > layer-1.txt
 					RUN echo -n old-layer-2 > layer-2.txt
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 
 				h.AssertNil(t, h.PullImage(dockerCli, repoName))
 				defer func() {
@@ -496,7 +496,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 					FROM busybox
 					LABEL repo_name_for_randomisation=%s
 					LABEL mykey=oldValue
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 			})
 
 			it("returns the image digest", func() {
@@ -551,7 +551,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 				h.CreateImageOnRemote(t, dockerCli, repoName, fmt.Sprintf(`
 					FROM scratch
 					LABEL repo_name_for_randomisation=%s
-				`, repoName), make(map[string]string))
+				`, repoName), nil)
 			})
 
 			it("returns true, nil", func() {

--- a/restorer_test.go
+++ b/restorer_test.go
@@ -55,7 +55,7 @@ func testRestorer(t *testing.T, when spec.G, it spec.S) {
 			it.Before(func() {
 				factory, err := image.NewFactory()
 				h.AssertNil(t, err)
-				cacheImage, err = factory.NewLocal("not-exist", false)
+				cacheImage, err = factory.NewLocal("not-exist")
 				h.AssertNil(t, err)
 			})
 

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -113,7 +113,7 @@ func Eventually(t *testing.T, test func() bool, every time.Duration, timeout tim
 
 var getBuildImageOnce sync.Once
 
-func CreateImageOnLocal(t *testing.T, dockerCli *dockercli.Client, repoName, dockerFile string) {
+func CreateImageOnLocal(t *testing.T, dockerCli *dockercli.Client, repoName, dockerFile string, labels map[string]string) {
 	ctx := context.Background()
 
 	buildContext, err := CreateSingleFileTar("Dockerfile", dockerFile)
@@ -124,6 +124,7 @@ func CreateImageOnLocal(t *testing.T, dockerCli *dockercli.Client, repoName, doc
 		SuppressOutput: true,
 		Remove:         true,
 		ForceRemove:    true,
+		Labels:         labels,
 	})
 	AssertNil(t, err)
 
@@ -131,11 +132,11 @@ func CreateImageOnLocal(t *testing.T, dockerCli *dockercli.Client, repoName, doc
 	res.Body.Close()
 }
 
-func CreateImageOnRemote(t *testing.T, dockerCli *dockercli.Client, repoName, dockerFile string) string {
+func CreateImageOnRemote(t *testing.T, dockerCli *dockercli.Client, repoName, dockerFile string, labels map[string]string) string {
 	t.Helper()
 	defer DockerRmi(dockerCli, repoName)
 
-	CreateImageOnLocal(t, dockerCli, repoName, dockerFile)
+	CreateImageOnLocal(t, dockerCli, repoName, dockerFile, labels)
 
 	var topLayer string
 	inspect, _, err := dockerCli.ImageInspectWithRaw(context.TODO(), repoName)


### PR DESCRIPTION
- Lifecycle farms out responsibility of pulling to pack
- We want to ensure that pack does not return an error in the
  situation where we can pull from remote but the image only exists
locally

[buildpack/pack#90]
