### PR TITLE
travis pushes pack/*:rc images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,18 +15,18 @@ jobs:
     script: |
       test -z "$(bin/format | tee >(cat >&2))"
       go test -v -parallel=1 -p=1 -count=1 ./...
-  - stage: build and push images
+  - stage: build and push rc images
     if: branch = master AND fork = false
     env:
     - secure: "ya3FQMvAyu0fWQFO7tTAP9CepONq9cH4Xt3beIdxlUI4kcdwTBDASzMX9QEn5dIPHp2rRy5DuPIB67SqsCQcVA2v2Wmj3d/GVbcTIX8iNpI5T2kFNgoHWH3pLUuigcS22rEImphiLeI+xGDwpG0t3PbTdyx5zc+jASndMxQxmWH9sIJqa6h0i7hqPuaWttBfmnEWR/CWxDI64I49y8C8xOJdN/k+o5R3XK5Qvh70hYH5UIxWF2LwvD3PgcBF+/995ufQmLBMo6XPGWnEdu85UTIj1rAsmh+Ld3b47GKYDXk/jVBcLRTj1jhz/6irDu4/ZpZcb1a9Ocjbcn5LMNzFfi3kPqizZ0buN8w0hS2vfx5mQ1xg9pCzOSw164wyN+4McCEI1fwKujPkbPtiSOkF4GUPBx6w3ezRFZO6a50jQQNVDP24nVD5Q+N8cUcGIFfcaNmyv8noxAsB2shAgEHycYId6ufGoJhdTt40tDGilSvqTGhQKiSWxg9k0VJpsmlXRxfEfaaTkpQowKPtzUsTjfeH14mI2EsZ8AJsv8V9mdWvkJE0tg8DPsCZ8sDbB9gK0VHExRBkcgmlU6+c3/qvitojSEBAD8CSUS8dRCwoTn8PKB1k9BndO9rhLkSlu9SKl8XFbgGYW5hW+gQYsIUz5iswA3EL0FyjGNjavzTtAqw="
     - secure: "McMI5lalBxrsns6ZlekhwqQM0y8h2db3M49KppGVgCD3ShsKubQ14RLRT8tqs60f+UBVzEaMarqNXcSLcCiegH+gMbJazYGVog3vVt8m1AbQEQiSecuQ3GRW00jrjPOU82wJPmj3Xw/L4Pi9PKN+Fmol802gbZMQ69OhLAjiNic0jW+HJ4ZFxrD2ns4BmdMeBURGamZeyMsG3ISzgGfl+LoanV92N7de2bRl3tG88qquyrlVjOK5G+wmp+AK+LdeDly94kSrq1/Pgvpq5xIjK+5bdtn5cIEWaMPtfeKMU+UQjIWVWWU4BQ6ZdktKz6BumP1VGyP9JfNdH269e6UG/KM75QQEDAsv9Daq/oy2WEKMjs4LGv9OOsdzwPRrxOt+EWHwVOOXOXfhYMw5v250naqXAsZmO4PsUqmz8JsTuIVRttZX761d4f/JuPNpeE7GgxTc9D4VxziIl6ksDHrpRRQW4Hc4fznhBsUF7lyomCrwAWYSsZP4YBTYdykgKf0nNmf+iskzoIZfPuvzvWIim0K+ax5vp9B9ocd1mwQd5zPoAoYZRGhipw7d2hbkf8h8dakKdY8y/nBzomfXW1+4LFuuKSyELZg0z0rGu4t/jW6gHuILGCvPqBtCNIRTQSvLwk7Gzt/lKqZOv9P6Luh/UCI+mq+/lWyBy9zYUP0Swpc="
     script:
-    - images/bin/build -v "0.0.1-rc.$TRAVIS_BUILD_NUMBER"
+    - images/bin/build -v "rc"
     - echo "$DOCKERHUB_PASSWORD" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
-    - docker push "packs/base:0.0.1-rc.$TRAVIS_BUILD_NUMBER"
-    - docker push "packs/build:0.0.1-rc.$TRAVIS_BUILD_NUMBER"
-    - docker push "packs/run:0.0.1-rc.$TRAVIS_BUILD_NUMBER"
-    - docker push "packs/samples:0.0.1-rc.$TRAVIS_BUILD_NUMBER"
+    - docker push "packs/base:rc"
+    - docker push "packs/build:rc"
+    - docker push "packs/run:rc"
+    - docker push "packs/samples:rc"
   - stage: build and publish v3alpha2 images
     if: branch = v3alpha2
     env:


### PR DESCRIPTION
* release candidate images are now built by concourse (https://ci.buildpacks.io)
* pack travis build will be able to test against these dev images

Signed-off-by: Emily Casey <ecasey@pivotal.io>
Signed-off-by: Andrew Meyer <ameyer@pivotal.io>