### PR TITLE
Add Delete to local image

### DIFF
--- a/cmd/cacher/main.go
+++ b/cmd/cacher/main.go
@@ -71,8 +71,10 @@ func cache() error {
 	if err != nil {
 		return err
 	}
+
 	if err := cacher.Cache(layersDir, origCacheImage, factory.NewEmptyLocal(cacheImageTag)); err != nil {
 		return cmd.FailErrCode(err, cmd.CodeFailed)
 	}
-	return nil
+
+	return origCacheImage.Delete()
 }

--- a/image/image.go
+++ b/image/image.go
@@ -19,4 +19,5 @@ type Image interface {
 	Save() (string, error)
 	Found() (bool, error)
 	GetLayer(string) (io.ReadCloser, error)
+	Delete() error
 }

--- a/image/local.go
+++ b/image/local.go
@@ -53,7 +53,7 @@ func (f *Factory) NewLocal(repoName string) (*Local, error) {
 	}, nil
 }
 
-func (f *Factory) NewEmptyLocal(repoName string) Image {
+func (f *Factory) NewEmptyLocal(repoName string) *Local {
 	inspect := dockertypes.ImageInspect{}
 	inspect.Config = &container.Config{
 		Labels: map[string]string{},

--- a/image/local.go
+++ b/image/local.go
@@ -25,7 +25,7 @@ import (
 	"github.com/buildpack/lifecycle/archive"
 )
 
-type local struct {
+type Local struct {
 	RepoName         string
 	Docker           *dockerclient.Client
 	Inspect          types.ImageInspect
@@ -38,13 +38,13 @@ type local struct {
 	easyAddLayers    []string
 }
 
-func (f *Factory) NewLocal(repoName string) (Image, error) {
+func (f *Factory) NewLocal(repoName string) (*Local, error) {
 	inspect, _, err := f.Docker.ImageInspectWithRaw(context.Background(), repoName)
 	if err != nil && !dockerclient.IsErrNotFound(err) {
 		return nil, err
 	}
 
-	return &local{
+	return &Local{
 		Docker:     f.Docker,
 		RepoName:   repoName,
 		Inspect:    inspect,
@@ -58,7 +58,7 @@ func (f *Factory) NewEmptyLocal(repoName string) Image {
 	inspect.Config = &container.Config{
 		Labels: map[string]string{},
 	}
-	return &local{
+	return &Local{
 		RepoName: repoName,
 		Docker:   f.Docker,
 		Inspect:  inspect,
@@ -66,7 +66,7 @@ func (f *Factory) NewEmptyLocal(repoName string) Image {
 	}
 }
 
-func (l *local) Label(key string) (string, error) {
+func (l *Local) Label(key string) (string, error) {
 	if l.Inspect.Config == nil {
 		return "", fmt.Errorf("failed to get label, image '%s' does not exist", l.RepoName)
 	}
@@ -74,7 +74,7 @@ func (l *local) Label(key string) (string, error) {
 	return labels[key], nil
 }
 
-func (l *local) Env(key string) (string, error) {
+func (l *Local) Env(key string) (string, error) {
 	if l.Inspect.Config == nil {
 		return "", fmt.Errorf("failed to get env var, image '%s' does not exist", l.RepoName)
 	}
@@ -87,7 +87,7 @@ func (l *local) Env(key string) (string, error) {
 	return "", nil
 }
 
-func (l *local) Rename(name string) {
+func (l *Local) Rename(name string) {
 	l.easyAddLayers = nil
 	if inspect, _, err := l.Docker.ImageInspectWithRaw(context.TODO(), name); err == nil {
 		if len(inspect.RootFS.Layers) > len(l.Inspect.RootFS.Layers) {
@@ -98,15 +98,15 @@ func (l *local) Rename(name string) {
 	l.RepoName = name
 }
 
-func (l *local) Name() string {
+func (l *Local) Name() string {
 	return l.RepoName
 }
 
-func (l *local) Found() (bool, error) {
+func (l *Local) Found() (bool, error) {
 	return l.Inspect.Config != nil, nil
 }
 
-func (l *local) Digest() (string, error) {
+func (l *Local) Digest() (string, error) {
 	if found, err := l.Found(); err != nil {
 		return "", errors.Wrap(err, "determining image existence")
 	} else if !found {
@@ -122,7 +122,7 @@ func (l *local) Digest() (string, error) {
 	return parts[1], nil
 }
 
-func (l *local) Rebase(baseTopLayer string, newBase Image) error {
+func (l *Local) Rebase(baseTopLayer string, newBase Image) error {
 	ctx := context.Background()
 
 	// FIND TOP LAYER
@@ -173,7 +173,7 @@ func (l *local) Rebase(baseTopLayer string, newBase Image) error {
 	return nil
 }
 
-func (l *local) SetLabel(key, val string) error {
+func (l *Local) SetLabel(key, val string) error {
 	if l.Inspect.Config == nil {
 		return fmt.Errorf("failed to set label, image '%s' does not exist", l.RepoName)
 	}
@@ -181,7 +181,7 @@ func (l *local) SetLabel(key, val string) error {
 	return nil
 }
 
-func (l *local) SetEnv(key, val string) error {
+func (l *Local) SetEnv(key, val string) error {
 	if l.Inspect.Config == nil {
 		return fmt.Errorf("failed to set env var, image '%s' does not exist", l.RepoName)
 	}
@@ -189,7 +189,7 @@ func (l *local) SetEnv(key, val string) error {
 	return nil
 }
 
-func (l *local) SetEntrypoint(ep ...string) error {
+func (l *Local) SetEntrypoint(ep ...string) error {
 	if l.Inspect.Config == nil {
 		return fmt.Errorf("failed to set entrypoint, image '%s' does not exist", l.RepoName)
 	}
@@ -197,7 +197,7 @@ func (l *local) SetEntrypoint(ep ...string) error {
 	return nil
 }
 
-func (l *local) SetCmd(cmd ...string) error {
+func (l *Local) SetCmd(cmd ...string) error {
 	if l.Inspect.Config == nil {
 		return fmt.Errorf("failed to set cmd, image '%s' does not exist", l.RepoName)
 	}
@@ -205,13 +205,13 @@ func (l *local) SetCmd(cmd ...string) error {
 	return nil
 }
 
-func (l *local) TopLayer() (string, error) {
+func (l *Local) TopLayer() (string, error) {
 	all := l.Inspect.RootFS.Layers
 	topLayer := all[len(all)-1]
 	return topLayer, nil
 }
 
-func (l *local) GetLayer(sha string) (io.ReadCloser, error) {
+func (l *Local) GetLayer(sha string) (io.ReadCloser, error) {
 	l.prevDownload()
 	layerID, ok := l.prevMap[sha]
 	if !ok {
@@ -220,7 +220,7 @@ func (l *local) GetLayer(sha string) (io.ReadCloser, error) {
 	return os.Open(filepath.Join(l.prevDir, layerID))
 }
 
-func (l *local) AddLayer(path string) error {
+func (l *Local) AddLayer(path string) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return errors.Wrapf(err, "AddLayer: open layer: %s", path)
@@ -239,7 +239,7 @@ func (l *local) AddLayer(path string) error {
 	return nil
 }
 
-func (l *local) ReuseLayer(sha string) error {
+func (l *Local) ReuseLayer(sha string) error {
 	if len(l.easyAddLayers) > 0 && l.easyAddLayers[0] == sha {
 		l.Inspect.RootFS.Layers = append(l.Inspect.RootFS.Layers, sha)
 		l.layerPaths = append(l.layerPaths, "")
@@ -259,7 +259,7 @@ func (l *local) ReuseLayer(sha string) error {
 	return l.AddLayer(filepath.Join(l.prevDir, reuseLayer))
 }
 
-func (l *local) Save() (string, error) {
+func (l *Local) Save() (string, error) {
 	ctx := context.Background()
 	done := make(chan error)
 
@@ -346,7 +346,23 @@ func (l *local) Save() (string, error) {
 	return imgID, err
 }
 
-func (l *local) prevDownload() error {
+func (l *Local) Delete() error {
+	if found, err := l.Found(); err != nil {
+		return errors.Wrap(err, "determining image existence")
+	} else if found {
+		options := dockertypes.ImageRemoveOptions{
+			Force:         true,
+			PruneChildren: true,
+		}
+		_, err := l.Docker.ImageRemove(context.Background(), l.Inspect.ID, options)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (l *Local) prevDownload() error {
 	var outerErr error
 	l.prevOnce.Do(func() {
 		ctx := context.Background()

--- a/image/local_test.go
+++ b/image/local_test.go
@@ -34,7 +34,7 @@ func TestLocal(t *testing.T) {
 	localTestRegistry.Start(t)
 	defer localTestRegistry.Stop(t)
 
-	spec.Run(t, "Local", testLocal, spec.Parallel(), spec.Report(report.Terminal{}))
+	spec.Run(t, "local", testLocal, spec.Parallel(), spec.Report(report.Terminal{}))
 }
 
 func testLocal(t *testing.T, when spec.G, it spec.S) {
@@ -757,7 +757,7 @@ func testLocal(t *testing.T, when spec.G, it spec.S) {
 
 		when("the image does exist", func() {
 			var (
-				origImg *image.Local
+				origImg image.Image
 				origID  string
 			)
 
@@ -793,9 +793,9 @@ func testLocal(t *testing.T, when spec.G, it spec.S) {
 				const newTag = "different-tag"
 
 				it.Before(func() {
-					h.AssertNil(t, dockerCli.ImageTag(context.TODO(), origImg.RepoName, newTag))
+					h.AssertNil(t, dockerCli.ImageTag(context.TODO(), origImg.Name(), newTag))
 
-					_, err := dockerCli.ImageRemove(context.TODO(), origImg.RepoName, dockertypes.ImageRemoveOptions{})
+					_, err := dockerCli.ImageRemove(context.TODO(), origImg.Name(), dockertypes.ImageRemoveOptions{})
 					h.AssertNil(t, err)
 				})
 

--- a/image/remote.go
+++ b/image/remote.go
@@ -20,7 +20,7 @@ import (
 	"github.com/buildpack/lifecycle/image/auth"
 )
 
-type Remote struct {
+type remote struct {
 	keychain   authn.Keychain
 	RepoName   string
 	Image      v1.Image
@@ -28,13 +28,13 @@ type Remote struct {
 	prevOnce   *sync.Once
 }
 
-func (f *Factory) NewRemote(repoName string) (*Remote, error) {
+func (f *Factory) NewRemote(repoName string) (Image, error) {
 	image, err := newV1Image(f.Keychain, repoName)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Remote{
+	return &remote{
 		keychain: f.Keychain,
 		RepoName: repoName,
 		Image:    image,
@@ -54,7 +54,7 @@ func newV1Image(keychain authn.Keychain, repoName string) (v1.Image, error) {
 	return image, nil
 }
 
-func (r *Remote) Label(key string) (string, error) {
+func (r *remote) Label(key string) (string, error) {
 	cfg, err := r.Image.ConfigFile()
 	if err != nil || cfg == nil {
 		return "", fmt.Errorf("failed to get label, image '%s' does not exist", r.RepoName)
@@ -64,7 +64,7 @@ func (r *Remote) Label(key string) (string, error) {
 
 }
 
-func (r *Remote) Env(key string) (string, error) {
+func (r *remote) Env(key string) (string, error) {
 	cfg, err := r.Image.ConfigFile()
 	if err != nil || cfg == nil {
 		return "", fmt.Errorf("failed to get env var, image '%s' does not exist", r.RepoName)
@@ -78,15 +78,15 @@ func (r *Remote) Env(key string) (string, error) {
 	return "", nil
 }
 
-func (r *Remote) Rename(name string) {
+func (r *remote) Rename(name string) {
 	r.RepoName = name
 }
 
-func (r *Remote) Name() string {
+func (r *remote) Name() string {
 	return r.RepoName
 }
 
-func (r *Remote) Found() (bool, error) {
+func (r *remote) Found() (bool, error) {
 	if _, err := r.Image.RawManifest(); err != nil {
 		if transportErr, ok := err.(*transport.Error); ok && len(transportErr.Errors) > 0 {
 			switch transportErr.Errors[0].Code {
@@ -99,7 +99,7 @@ func (r *Remote) Found() (bool, error) {
 	return true, nil
 }
 
-func (r *Remote) Digest() (string, error) {
+func (r *remote) Digest() (string, error) {
 	hash, err := r.Image.Digest()
 	if err != nil {
 		return "", fmt.Errorf("failed to get digest for image '%s': %s", r.RepoName, err)
@@ -107,8 +107,8 @@ func (r *Remote) Digest() (string, error) {
 	return hash.String(), nil
 }
 
-func (r *Remote) Rebase(baseTopLayer string, newBase Image) error {
-	newBaseRemote, ok := newBase.(*Remote)
+func (r *remote) Rebase(baseTopLayer string, newBase Image) error {
+	newBaseRemote, ok := newBase.(*remote)
 	if !ok {
 		return errors.New("expected new base to be a remote image")
 	}
@@ -121,7 +121,7 @@ func (r *Remote) Rebase(baseTopLayer string, newBase Image) error {
 	return nil
 }
 
-func (r *Remote) SetLabel(key, val string) error {
+func (r *remote) SetLabel(key, val string) error {
 	configFile, err := r.Image.ConfigFile()
 	if err != nil {
 		return err
@@ -135,7 +135,7 @@ func (r *Remote) SetLabel(key, val string) error {
 	return err
 }
 
-func (r *Remote) SetEnv(key, val string) error {
+func (r *remote) SetEnv(key, val string) error {
 	configFile, err := r.Image.ConfigFile()
 	if err != nil {
 		return err
@@ -157,7 +157,7 @@ func (r *Remote) SetEnv(key, val string) error {
 	return err
 }
 
-func (r *Remote) SetEntrypoint(ep ...string) error {
+func (r *remote) SetEntrypoint(ep ...string) error {
 	configFile, err := r.Image.ConfigFile()
 	if err != nil {
 		return err
@@ -168,7 +168,7 @@ func (r *Remote) SetEntrypoint(ep ...string) error {
 	return err
 }
 
-func (r *Remote) SetCmd(cmd ...string) error {
+func (r *remote) SetCmd(cmd ...string) error {
 	configFile, err := r.Image.ConfigFile()
 	if err != nil {
 		return err
@@ -179,7 +179,7 @@ func (r *Remote) SetCmd(cmd ...string) error {
 	return err
 }
 
-func (r *Remote) TopLayer() (string, error) {
+func (r *remote) TopLayer() (string, error) {
 	all, err := r.Image.Layers()
 	if err != nil {
 		return "", err
@@ -192,11 +192,11 @@ func (r *Remote) TopLayer() (string, error) {
 	return hex.String(), nil
 }
 
-func (r *Remote) GetLayer(string) (io.ReadCloser, error) {
+func (r *remote) GetLayer(string) (io.ReadCloser, error) {
 	panic("not implemented")
 }
 
-func (r *Remote) AddLayer(path string) error {
+func (r *remote) AddLayer(path string) error {
 	layer, err := tarball.LayerFromFile(path)
 	if err != nil {
 		return err
@@ -208,7 +208,7 @@ func (r *Remote) AddLayer(path string) error {
 	return nil
 }
 
-func (r *Remote) ReuseLayer(sha string) error {
+func (r *remote) ReuseLayer(sha string) error {
 	var outerErr error
 
 	r.prevOnce.Do(func() {
@@ -247,7 +247,7 @@ func findLayerWithSha(layers []v1.Layer, sha string) (v1.Layer, error) {
 	return nil, fmt.Errorf(`previous image did not have layer with sha '%s'`, sha)
 }
 
-func (r *Remote) Save() (string, error) {
+func (r *remote) Save() (string, error) {
 	ref, auth, err := auth.ReferenceForRepoName(r.keychain, r.RepoName)
 	if err != nil {
 		return "", err
@@ -268,6 +268,10 @@ func (r *Remote) Save() (string, error) {
 	}
 
 	return hex.String(), nil
+}
+
+func (r *remote) Delete() error {
+	return errors.New("remote image does not implement Delete")
 }
 
 type subImage struct {

--- a/image/remote_test.go
+++ b/image/remote_test.go
@@ -56,7 +56,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 
 	when("#label", func() {
 		when("image exists", func() {
-			var img *image.Remote
+			var img image.Image
 			it.Before(func() {
 				h.CreateImageOnRemote(t, dockerCli, repoName, fmt.Sprintf(`
 					FROM scratch
@@ -154,7 +154,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("#SetLabel", func() {
-		var img *image.Remote
+		var img image.Image
 		when("image exists", func() {
 			it.Before(func() {
 				h.CreateImageOnRemote(t, dockerCli, repoName, fmt.Sprintf(`
@@ -189,7 +189,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 
 	when("#SetEnv", func() {
 		var (
-			img *image.Remote
+			img image.Image
 		)
 		it.Before(func() {
 			var err error
@@ -221,7 +221,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 
 	when("#SetEntrypoint", func() {
 		var (
-			img *image.Remote
+			img image.Image
 		)
 		it.Before(func() {
 			var err error
@@ -252,7 +252,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 
 	when("#SetCmd", func() {
 		var (
-			img *image.Remote
+			img image.Image
 		)
 		it.Before(func() {
 			var err error
@@ -375,7 +375,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 	when("#AddLayer", func() {
 		var (
 			tarPath string
-			img     *image.Remote
+			img     image.Image
 		)
 		it.Before(func() {
 			h.CreateImageOnRemote(t, dockerCli, repoName, fmt.Sprintf(`
@@ -425,7 +425,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 		when("previous image", func() {
 			var (
 				layer2SHA string
-				img       *image.Remote
+				img       image.Image
 			)
 
 			it.Before(func() {

--- a/image/remote_test.go
+++ b/image/remote_test.go
@@ -56,7 +56,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 
 	when("#label", func() {
 		when("image exists", func() {
-			var img image.Image
+			var img *image.Remote
 			it.Before(func() {
 				h.CreateImageOnRemote(t, dockerCli, repoName, fmt.Sprintf(`
 					FROM scratch
@@ -154,7 +154,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("#SetLabel", func() {
-		var img image.Image
+		var img *image.Remote
 		when("image exists", func() {
 			it.Before(func() {
 				h.CreateImageOnRemote(t, dockerCli, repoName, fmt.Sprintf(`
@@ -189,7 +189,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 
 	when("#SetEnv", func() {
 		var (
-			img image.Image
+			img *image.Remote
 		)
 		it.Before(func() {
 			var err error
@@ -221,7 +221,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 
 	when("#SetEntrypoint", func() {
 		var (
-			img image.Image
+			img *image.Remote
 		)
 		it.Before(func() {
 			var err error
@@ -252,7 +252,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 
 	when("#SetCmd", func() {
 		var (
-			img image.Image
+			img *image.Remote
 		)
 		it.Before(func() {
 			var err error
@@ -375,7 +375,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 	when("#AddLayer", func() {
 		var (
 			tarPath string
-			img     image.Image
+			img     *image.Remote
 		)
 		it.Before(func() {
 			h.CreateImageOnRemote(t, dockerCli, repoName, fmt.Sprintf(`
@@ -425,7 +425,7 @@ func testRemote(t *testing.T, when spec.G, it spec.S) {
 		when("previous image", func() {
 			var (
 				layer2SHA string
-				img       image.Image
+				img       *image.Remote
 			)
 
 			it.Before(func() {

--- a/testhelpers/test_image.go
+++ b/testhelpers/test_image.go
@@ -29,6 +29,7 @@ func NewFakeImage(t *testing.T, name, topLayerSha, digest string) *FakeImage {
 type FakeImage struct {
 	t            *testing.T
 	alreadySaved bool
+	deleted      bool
 	layers       []string
 	layersMap    map[string]string
 	reusedLayers []string
@@ -123,8 +124,13 @@ func (f *FakeImage) Save() (string, error) {
 	return "saved-digest-from-fake-run-image", nil
 }
 
-func (FakeImage) Found() (bool, error) {
-	return true, nil
+func (f *FakeImage) Delete() error {
+	f.deleted = true
+	return nil
+}
+
+func (f *FakeImage) Found() (bool, error) {
+	return !f.deleted, nil
 }
 
 // test methods

--- a/testmock/image.go
+++ b/testmock/image.go
@@ -36,7 +36,6 @@ func (m *MockImage) EXPECT() *MockImageMockRecorder {
 
 // AddLayer mocks base method
 func (m *MockImage) AddLayer(arg0 string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddLayer", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -44,13 +43,23 @@ func (m *MockImage) AddLayer(arg0 string) error {
 
 // AddLayer indicates an expected call of AddLayer
 func (mr *MockImageMockRecorder) AddLayer(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddLayer", reflect.TypeOf((*MockImage)(nil).AddLayer), arg0)
+}
+
+// Delete mocks base method
+func (m *MockImage) Delete() error {
+	ret := m.ctrl.Call(m, "Delete")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete
+func (mr *MockImageMockRecorder) Delete() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockImage)(nil).Delete))
 }
 
 // Digest mocks base method
 func (m *MockImage) Digest() (string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Digest")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -59,13 +68,11 @@ func (m *MockImage) Digest() (string, error) {
 
 // Digest indicates an expected call of Digest
 func (mr *MockImageMockRecorder) Digest() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Digest", reflect.TypeOf((*MockImage)(nil).Digest))
 }
 
 // Env mocks base method
 func (m *MockImage) Env(arg0 string) (string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Env", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -74,13 +81,11 @@ func (m *MockImage) Env(arg0 string) (string, error) {
 
 // Env indicates an expected call of Env
 func (mr *MockImageMockRecorder) Env(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Env", reflect.TypeOf((*MockImage)(nil).Env), arg0)
 }
 
 // Found mocks base method
 func (m *MockImage) Found() (bool, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Found")
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -89,7 +94,6 @@ func (m *MockImage) Found() (bool, error) {
 
 // Found indicates an expected call of Found
 func (mr *MockImageMockRecorder) Found() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Found", reflect.TypeOf((*MockImage)(nil).Found))
 }
 
@@ -108,7 +112,6 @@ func (mr *MockImageMockRecorder) GetLayer(arg0 interface{}) *gomock.Call {
 
 // Label mocks base method
 func (m *MockImage) Label(arg0 string) (string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Label", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -117,13 +120,11 @@ func (m *MockImage) Label(arg0 string) (string, error) {
 
 // Label indicates an expected call of Label
 func (mr *MockImageMockRecorder) Label(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Label", reflect.TypeOf((*MockImage)(nil).Label), arg0)
 }
 
 // Name mocks base method
 func (m *MockImage) Name() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -131,13 +132,11 @@ func (m *MockImage) Name() string {
 
 // Name indicates an expected call of Name
 func (mr *MockImageMockRecorder) Name() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockImage)(nil).Name))
 }
 
 // Rebase mocks base method
 func (m *MockImage) Rebase(arg0 string, arg1 image.Image) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Rebase", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -145,25 +144,21 @@ func (m *MockImage) Rebase(arg0 string, arg1 image.Image) error {
 
 // Rebase indicates an expected call of Rebase
 func (mr *MockImageMockRecorder) Rebase(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rebase", reflect.TypeOf((*MockImage)(nil).Rebase), arg0, arg1)
 }
 
 // Rename mocks base method
 func (m *MockImage) Rename(arg0 string) {
-	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Rename", arg0)
 }
 
 // Rename indicates an expected call of Rename
 func (mr *MockImageMockRecorder) Rename(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rename", reflect.TypeOf((*MockImage)(nil).Rename), arg0)
 }
 
 // ReuseLayer mocks base method
 func (m *MockImage) ReuseLayer(arg0 string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReuseLayer", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -171,13 +166,11 @@ func (m *MockImage) ReuseLayer(arg0 string) error {
 
 // ReuseLayer indicates an expected call of ReuseLayer
 func (mr *MockImageMockRecorder) ReuseLayer(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReuseLayer", reflect.TypeOf((*MockImage)(nil).ReuseLayer), arg0)
 }
 
 // Save mocks base method
 func (m *MockImage) Save() (string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Save")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -186,13 +179,11 @@ func (m *MockImage) Save() (string, error) {
 
 // Save indicates an expected call of Save
 func (mr *MockImageMockRecorder) Save() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Save", reflect.TypeOf((*MockImage)(nil).Save))
 }
 
 // SetCmd mocks base method
 func (m *MockImage) SetCmd(arg0 ...string) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
@@ -204,13 +195,11 @@ func (m *MockImage) SetCmd(arg0 ...string) error {
 
 // SetCmd indicates an expected call of SetCmd
 func (mr *MockImageMockRecorder) SetCmd(arg0 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCmd", reflect.TypeOf((*MockImage)(nil).SetCmd), arg0...)
 }
 
 // SetEntrypoint mocks base method
 func (m *MockImage) SetEntrypoint(arg0 ...string) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
@@ -222,13 +211,11 @@ func (m *MockImage) SetEntrypoint(arg0 ...string) error {
 
 // SetEntrypoint indicates an expected call of SetEntrypoint
 func (mr *MockImageMockRecorder) SetEntrypoint(arg0 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEntrypoint", reflect.TypeOf((*MockImage)(nil).SetEntrypoint), arg0...)
 }
 
 // SetEnv mocks base method
 func (m *MockImage) SetEnv(arg0, arg1 string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetEnv", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -236,13 +223,11 @@ func (m *MockImage) SetEnv(arg0, arg1 string) error {
 
 // SetEnv indicates an expected call of SetEnv
 func (mr *MockImageMockRecorder) SetEnv(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEnv", reflect.TypeOf((*MockImage)(nil).SetEnv), arg0, arg1)
 }
 
 // SetLabel mocks base method
 func (m *MockImage) SetLabel(arg0, arg1 string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetLabel", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -250,13 +235,11 @@ func (m *MockImage) SetLabel(arg0, arg1 string) error {
 
 // SetLabel indicates an expected call of SetLabel
 func (mr *MockImageMockRecorder) SetLabel(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLabel", reflect.TypeOf((*MockImage)(nil).SetLabel), arg0, arg1)
 }
 
 // TopLayer mocks base method
 func (m *MockImage) TopLayer() (string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TopLayer")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -265,6 +248,5 @@ func (m *MockImage) TopLayer() (string, error) {
 
 // TopLayer indicates an expected call of TopLayer
 func (mr *MockImageMockRecorder) TopLayer() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TopLayer", reflect.TypeOf((*MockImage)(nil).TopLayer))
 }


### PR DESCRIPTION
- Make image/local and image/remote structs public and
  return them from the image factory instead of the
  image interface
- Delete the original cache image after the cache step

Signed-off-by: Danny Joyce <djoyce@pivotal.io>
Signed-off-by: Andrew Meyer <ameyer@pivotal.io>