### PR TITLE
removes "wall of shas"

### DIFF
--- a/cmd/analyzer/main.go
+++ b/cmd/analyzer/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"io/ioutil"
 	"log"
 	"os"
 
@@ -34,6 +35,9 @@ func init() {
 }
 
 func main() {
+	// suppress output from libraries, lifecycle will not use standard logger
+	log.SetOutput(ioutil.Discard)
+
 	flag.Parse()
 	repoName = flag.Arg(0)
 	if flag.NArg() > 1 || repoName == "" {

--- a/cmd/builder/main.go
+++ b/cmd/builder/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"flag"
+	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -30,6 +32,9 @@ func init() {
 }
 
 func main() {
+	// suppress output from libraries, lifecycle will not use standard logger
+	log.SetOutput(ioutil.Discard)
+
 	flag.Parse()
 	if flag.NArg() != 0 {
 		cmd.Exit(cmd.FailCode(cmd.CodeInvalidArgs, "parse arguments"))

--- a/cmd/cacher/main.go
+++ b/cmd/cacher/main.go
@@ -31,6 +31,9 @@ func init() {
 }
 
 func main() {
+	// suppress output from libraries, lifecycle will not use standard logger
+	log.SetOutput(ioutil.Discard)
+
 	flag.Parse()
 	if flag.NArg() > 0 {
 		args := map[string]interface{}{"narg": flag.NArg(), "layersDir": layersDir}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -137,7 +137,8 @@ func Exit(err error) {
 	if err == nil {
 		os.Exit(0)
 	}
-	log.Printf("Error: %s\n", err)
+	logger := log.New(os.Stderr, "", 0)
+	logger.Printf("Error: %s\n", err)
 	if err, ok := err.(*ErrorFail); ok {
 		os.Exit(err.Code)
 	}

--- a/cmd/detector/main.go
+++ b/cmd/detector/main.go
@@ -31,6 +31,9 @@ func init() {
 }
 
 func main() {
+	// suppress output from libraries, lifecycle will not use standard logger
+	log.SetOutput(ioutil.Discard)
+
 	flag.Parse()
 	if flag.NArg() != 0 {
 		cmd.Exit(cmd.FailCode(cmd.CodeInvalidArgs, "parse arguments"))

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -42,6 +42,9 @@ func init() {
 }
 
 func main() {
+	// suppress output from libraries, lifecycle will not use standard logger
+	log.SetOutput(ioutil.Discard)
+
 	flag.Parse()
 	if flag.NArg() > 1 || flag.Arg(0) == "" || runImageRef == "" {
 		args := map[string]interface{}{"narg": flag.NArg(), "runImage": runImageRef, "layersDir": layersDir}

--- a/cmd/restorer/main.go
+++ b/cmd/restorer/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 
@@ -30,6 +31,9 @@ func init() {
 }
 
 func main() {
+	// suppress output from libraries, lifecycle will not use standard logger
+	log.SetOutput(ioutil.Discard)
+
 	flag.Parse()
 	if flag.NArg() > 0 {
 		args := map[string]interface{}{"narg": flag.NArg(), "layersDir": layersDir}


### PR DESCRIPTION
* temporarily set output destination for standard logger to discard before writing a remote image
* surpresses ggcr output

[buildpack/roadmap#45]