### PR TITLE
Chown symlinks not their targets

### DIFF
--- a/layers.go
+++ b/layers.go
@@ -220,7 +220,7 @@ func recursiveChown(path string, uid, gid int) error {
 				return err
 			}
 		} else {
-			if err := os.Chown(filePath, uid, gid); err != nil {
+			if err := os.Lchown(filePath, uid, gid); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
`os.Chown` follows the symlink then tries to `chown` the target file. This returns `os.PathError` on broken symlinks (symlinks pointing at a file that doesn't exist).