### PR TITLE
Adds correct number of history entries when saving local image

### DIFF
--- a/image/local.go
+++ b/image/local.go
@@ -298,20 +298,13 @@ func (l *local) Save() (string, error) {
 	tw := tar.NewWriter(pw)
 	defer tw.Close()
 
-	imgConfig := map[string]interface{}{
-		"os":      "linux",
-		"created": time.Now().Format(time.RFC3339),
-		"config":  l.Inspect.Config,
-		"rootfs": map[string][]string{
-			"diff_ids": l.Inspect.RootFS.Layers,
-		},
-	}
-	formatted, err := json.Marshal(imgConfig)
+	configFile, err := l.configFile()
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "generate config file")
 	}
-	imgID := fmt.Sprintf("%x", sha256.Sum256(formatted))
-	if err := archive.AddTextToTar(tw, imgID+".json", formatted); err != nil {
+
+	imgID := fmt.Sprintf("%x", sha256.Sum256(configFile))
+	if err := archive.AddTextToTar(tw, imgID+".json", configFile); err != nil {
 		return "", err
 	}
 
@@ -335,7 +328,7 @@ func (l *local) Save() (string, error) {
 
 	}
 
-	formatted, err = json.Marshal([]map[string]interface{}{
+	manifest, err := json.Marshal([]map[string]interface{}{
 		{
 			"Config":   imgID + ".json",
 			"RepoTags": []string{repoName},
@@ -345,7 +338,8 @@ func (l *local) Save() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := archive.AddTextToTar(tw, "manifest.json", formatted); err != nil {
+
+	if err := archive.AddTextToTar(tw, "manifest.json", manifest); err != nil {
 		return "", err
 	}
 
@@ -359,13 +353,28 @@ func (l *local) Save() (string, error) {
 		l.prevMap = nil
 		l.prevOnce = &sync.Once{}
 	}
-	if _, _, err = l.Docker.ImageInspectWithRaw(context.Background(), imgID); err != nil && !dockerclient.IsErrNotFound(err) {
+
+	if _, _, err = l.Docker.ImageInspectWithRaw(context.Background(), imgID); err != nil {
+		if dockerclient.IsErrNotFound(err) {
+			return "", fmt.Errorf("save image '%s'", l.RepoName)
+		}
 		return "", err
-	} else if dockerclient.IsErrNotFound(err) {
-		return "", fmt.Errorf("save image '%s'", l.RepoName)
 	}
 
 	return imgID, err
+}
+
+func (l *local) configFile() ([]byte, error) {
+	imgConfig := map[string]interface{}{
+		"os":      "linux",
+		"created": time.Now().Format(time.RFC3339),
+		"config":  l.Inspect.Config,
+		"rootfs": map[string][]string{
+			"diff_ids": l.Inspect.RootFS.Layers,
+		},
+		"history": make([]struct{}, len(l.Inspect.RootFS.Layers)),
+	}
+	return json.Marshal(imgConfig)
 }
 
 func (l *local) Delete() error {


### PR DESCRIPTION
* enables pushing local images to registries that enforce shema 1 compat
* enables remote rebasing of images that were originally built locally

[buildpack/lifecycle#104]

Signed-off-by: Danny Joyce <djoyce@pivotal.io>
Signed-off-by: Emily Casey <ecasey@pivotal.io>