### PR TITLE
SetupCredHelpers will not overwrite cred helpers from docker config

### DIFF
--- a/cmd/analyzer/main.go
+++ b/cmd/analyzer/main.go
@@ -48,7 +48,7 @@ func main() {
 
 func analyzer() error {
 	if useHelpers {
-		if err := lifecycle.SetupCredHelpers(repoName); err != nil {
+		if err := lifecycle.SetupCredHelpers(os.Getenv("HOME"), repoName); err != nil {
 			return cmd.FailErr(err, "setup credential helpers")
 		}
 	}

--- a/cmd/analyzer/main.go
+++ b/cmd/analyzer/main.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/BurntSushi/toml"
 
@@ -48,7 +49,7 @@ func main() {
 
 func analyzer() error {
 	if useHelpers {
-		if err := lifecycle.SetupCredHelpers(os.Getenv("HOME"), repoName); err != nil {
+		if err := lifecycle.SetupCredHelpers(filepath.Join(os.Getenv("HOME"), ".docker"), repoName); err != nil {
 			return cmd.FailErr(err, "setup credential helpers")
 		}
 	}

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -63,7 +63,7 @@ func export() error {
 	}
 
 	if useHelpers {
-		if err := lifecycle.SetupCredHelpers(repoName, runImageRef); err != nil {
+		if err := lifecycle.SetupCredHelpers(os.Getenv("HOME"), repoName, runImageRef); err != nil {
 			return cmd.FailErr(err, "setup credential helpers")
 		}
 	}

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/BurntSushi/toml"
 
@@ -63,7 +64,7 @@ func export() error {
 	}
 
 	if useHelpers {
-		if err := lifecycle.SetupCredHelpers(os.Getenv("HOME"), repoName, runImageRef); err != nil {
+		if err := lifecycle.SetupCredHelpers(filepath.Join(os.Getenv("HOME"), ".docker"), repoName, runImageRef); err != nil {
 			return cmd.FailErr(err, "setup credential helpers")
 		}
 	}

--- a/cred_helpers.go
+++ b/cred_helpers.go
@@ -2,15 +2,14 @@ package lifecycle
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"github.com/google/go-containerregistry/pkg/name"
 	"os"
 	"path/filepath"
 	"regexp"
 )
 
-func SetupCredHelpers(home string, refs ...string) error {
-	dockerPath := filepath.Join(home, ".docker")
+func SetupCredHelpers(dockerPath string, refs ...string) error {
 	configPath := filepath.Join(dockerPath, "config.json")
 
 	config := map[string]interface{}{}
@@ -55,17 +54,15 @@ func SetupCredHelpers(home string, refs ...string) error {
 		return nil
 	}
 
+	ch, ok := config["credHelpers"].(map[string]interface{})
+	if !ok {
+		return errors.New("failed to parse docker config 'credHelpers'")
+	}
+
 	for k, v := range credHelpers {
-		ch, ok := config["credHelpers"].(map[string]interface{})
-		if !ok {
-			return fmt.Errorf("failed to parse docker config 'credHelpers'")
+		if _, ok := ch[k]; !ok {
+			ch[k] = v
 		}
-
-		if _, ok := ch[k]; ok {
-			continue
-		}
-
-		ch[k] = v
 	}
 
 	if err := os.MkdirAll(dockerPath, 0777); err != nil {

--- a/cred_helpers.go
+++ b/cred_helpers.go
@@ -2,18 +2,18 @@ package lifecycle
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/google/go-containerregistry/pkg/name"
 	"os"
 	"path/filepath"
 	"regexp"
 )
 
-func SetupCredHelpers(refs ...string) error {
-	dockerPath := filepath.Join(os.Getenv("HOME"), ".docker")
+func SetupCredHelpers(home string, refs ...string) error {
+	dockerPath := filepath.Join(home, ".docker")
 	configPath := filepath.Join(dockerPath, "config.json")
+
 	config := map[string]interface{}{}
-	credHelpers := map[string]string{}
-	config["credHelpers"] = credHelpers
 	if f, err := os.Open(configPath); err == nil {
 		err := json.NewDecoder(f).Decode(&config)
 		if f.Close(); err != nil {
@@ -22,12 +22,18 @@ func SetupCredHelpers(refs ...string) error {
 	} else if !os.IsNotExist(err) {
 		return err
 	}
-	added := false
+
+	if _, ok := config["credHelpers"]; !ok {
+		config["credHelpers"] = make(map[string]interface{})
+	}
+
+	credHelpers := make(map[string]string)
 	for _, refStr := range refs {
 		ref, err := name.ParseReference(refStr, name.WeakValidation)
 		if err != nil {
 			return err
 		}
+
 		registry := ref.Context().RegistryStr()
 		for _, ch := range []struct {
 			domain string
@@ -42,19 +48,35 @@ func SetupCredHelpers(refs ...string) error {
 				continue
 			}
 			credHelpers[registry] = ch.helper
-			added = true
 		}
 	}
-	if !added {
+
+	if len(credHelpers) == 0 {
 		return nil
 	}
+
+	for k, v := range credHelpers {
+		ch, ok := config["credHelpers"].(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("failed to parse docker config 'credHelpers'")
+		}
+
+		if _, ok := ch[k]; ok {
+			continue
+		}
+
+		ch[k] = v
+	}
+
 	if err := os.MkdirAll(dockerPath, 0777); err != nil {
 		return err
 	}
+
 	f, err := os.Create(configPath)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
+
 	return json.NewEncoder(f).Encode(config)
 }

--- a/cred_helpers_test.go
+++ b/cred_helpers_test.go
@@ -1,0 +1,119 @@
+package lifecycle_test
+
+import (
+	"encoding/json"
+	"github.com/buildpack/lifecycle"
+	h "github.com/buildpack/lifecycle/testhelpers"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCredHelpers(t *testing.T) {
+	spec.Run(t, "Builder", testCredHelpers, spec.Report(report.Terminal{}))
+}
+
+func testCredHelpers(t *testing.T, when spec.G, it spec.S) {
+	var (
+		err    error
+		tmpDir string
+	)
+
+	it.Before(func() {
+		tmpDir, err = ioutil.TempDir("", "")
+		h.AssertNil(t, err)
+	})
+
+	it.After(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	it("writes cred helpers for all known registries", func() {
+		err := lifecycle.SetupCredHelpers(tmpDir, "fake.gcr.io/test1", "fake.amazonaws.com/test2", "fake.azurecr.io/test3")
+		h.AssertNil(t, err)
+
+		config := parseCredHelpers(t, tmpDir)
+		h.AssertEq(t, config["fake.gcr.io"], "gcr")
+		h.AssertEq(t, config["fake.amazonaws.com"], "ecr-login")
+		h.AssertEq(t, config["fake.azurecr.io"], "acr")
+	})
+
+	when("a docker config exists", func() {
+		var (
+			dockerDir string
+		)
+
+		it.Before(func() {
+			dockerDir = filepath.Join(tmpDir, ".docker")
+			h.AssertNil(t, os.MkdirAll(dockerDir, 0755))
+		})
+
+		when("registry credentials do not exist in the config", func() {
+			it.Before(func() {
+				copyFile(t, filepath.Join("testdata", "cred_helpers", "config1.json"), filepath.Join(dockerDir, "config.json"))
+			})
+
+			it("adds the registry and helper to the credHelpers section", func() {
+				err := lifecycle.SetupCredHelpers(tmpDir, "fake.gcr.io/hello-world")
+				h.AssertNil(t, err)
+
+				config := parseCredHelpers(t, tmpDir)
+				h.AssertEq(t, config["fake.gcr.io"], "gcr")
+				h.AssertEq(t, config["fake.amazonaws.com"], "some-aws-helper")
+				h.AssertEq(t, config["fake.azurecr.io"], "some-azure-helper")
+			})
+		})
+
+		when("registry credentials do exist in the config", func() {
+			it.Before(func() {
+				copyFile(t, filepath.Join("testdata", "cred_helpers", "config2.json"), filepath.Join(dockerDir, "config.json"))
+			})
+
+			it("keeps the existing the registry and helper in the credHelpers section", func() {
+				err := lifecycle.SetupCredHelpers(tmpDir, "fake.gcr.io/hello-world")
+				h.AssertNil(t, err)
+
+				config := parseCredHelpers(t, tmpDir)
+				h.AssertEq(t, config["fake.amazonaws.com"], "some-aws-helper")
+				h.AssertEq(t, config["fake.azurecr.io"], "some-azure-helper")
+				h.AssertEq(t, config["fake.gcr.io"], "gcloud")
+			})
+		})
+	})
+
+	when("a docker config does not exist", func() {
+		it("creates a config file with registry and helper in the credHelpers section", func() {
+			err := lifecycle.SetupCredHelpers(tmpDir, "fake.gcr.io/hello-world")
+			h.AssertNil(t, err)
+
+			config := parseCredHelpers(t, tmpDir)
+			h.AssertEq(t, config["fake.gcr.io"], "gcr")
+		})
+	})
+}
+
+func copyFile(t *testing.T, src, dest string) {
+	buf, err := ioutil.ReadFile(src)
+	h.AssertNil(t, err)
+	h.AssertNil(t, ioutil.WriteFile(dest, buf, 0644))
+}
+
+func parseCredHelpers(t *testing.T, home string) map[string]interface{} {
+	f, err := os.Open(filepath.Join(home, ".docker", "config.json"))
+	h.AssertNil(t, err)
+	defer f.Close()
+
+	config := make(map[string]interface{})
+	err = json.NewDecoder(f).Decode(&config)
+	h.AssertNil(t, err)
+
+	helpers, ok := config["credHelpers"]
+	if !ok {
+		t.Fatalf("no credhelpers in config: %+v", config)
+	}
+
+	return helpers.(map[string]interface{})
+}

--- a/cred_helpers_test.go
+++ b/cred_helpers_test.go
@@ -42,18 +42,9 @@ func testCredHelpers(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("a docker config exists", func() {
-		var (
-			dockerDir string
-		)
-
-		it.Before(func() {
-			dockerDir = filepath.Join(tmpDir, ".docker")
-			h.AssertNil(t, os.MkdirAll(dockerDir, 0755))
-		})
-
 		when("registry credentials do not exist in the config", func() {
 			it.Before(func() {
-				copyFile(t, filepath.Join("testdata", "cred_helpers", "config1.json"), filepath.Join(dockerDir, "config.json"))
+				copyFile(t, filepath.Join("testdata", "cred_helpers", "config1.json"), filepath.Join(tmpDir, "config.json"))
 			})
 
 			it("adds the registry and helper to the credHelpers section", func() {
@@ -69,7 +60,7 @@ func testCredHelpers(t *testing.T, when spec.G, it spec.S) {
 
 		when("registry credentials do exist in the config", func() {
 			it.Before(func() {
-				copyFile(t, filepath.Join("testdata", "cred_helpers", "config2.json"), filepath.Join(dockerDir, "config.json"))
+				copyFile(t, filepath.Join("testdata", "cred_helpers", "config2.json"), filepath.Join(tmpDir, "config.json"))
 			})
 
 			it("keeps the existing the registry and helper in the credHelpers section", func() {
@@ -98,11 +89,11 @@ func testCredHelpers(t *testing.T, when spec.G, it spec.S) {
 func copyFile(t *testing.T, src, dest string) {
 	buf, err := ioutil.ReadFile(src)
 	h.AssertNil(t, err)
-	h.AssertNil(t, ioutil.WriteFile(dest, buf, 0644))
+	h.AssertNil(t, ioutil.WriteFile(dest, buf, 0666))
 }
 
-func parseCredHelpers(t *testing.T, home string) map[string]interface{} {
-	f, err := os.Open(filepath.Join(home, ".docker", "config.json"))
+func parseCredHelpers(t *testing.T, path string) map[string]interface{} {
+	f, err := os.Open(filepath.Join(path, "config.json"))
 	h.AssertNil(t, err)
 	defer f.Close()
 

--- a/testdata/cred_helpers/config1.json
+++ b/testdata/cred_helpers/config1.json
@@ -1,0 +1,6 @@
+{
+  "credHelpers": {
+    "fake.amazonaws.com": "some-aws-helper",
+    "fake.azurecr.io": "some-azure-helper"
+  }
+}

--- a/testdata/cred_helpers/config2.json
+++ b/testdata/cred_helpers/config2.json
@@ -1,0 +1,8 @@
+{
+  "credHelpers": {
+    "fake.amazonaws.com": "some-aws-helper",
+    "fake.azurecr.io": "some-azure-helper",
+    "fake.gcr.io": "gcloud",
+    "other.gcr.io": "gcloud"
+  }
+}


### PR DESCRIPTION
* Helpers will only be added if they do not already exist in the docker config
* The credHelpers section is re-used from the docker config rather than re-written

[buildpack/lifecycle#71]

Signed-off-by: Danny Joyce <djoyce@pivotal.io>