### PR TITLE
Fake image tracks saved layers in a temp dir

### DIFF
--- a/image/fakes/image.go
+++ b/image/fakes/image.go
@@ -47,6 +47,7 @@ type Image struct {
 	cmd          []string
 	base         string
 	createdAt    time.Time
+	layerDir     string
 }
 
 func (f *Image) CreatedAt() (time.Time, error) {
@@ -154,7 +155,43 @@ func (f *Image) ReuseLayer(sha string) error {
 func (f *Image) Save() (string, error) {
 	f.assertNotAlreadySaved()
 	f.alreadySaved = true
+
+	var err error
+	f.layerDir, err = ioutil.TempDir("", "fake-image")
+	if err != nil {
+		f.t.Fatalf("failed to create tmpDir: %s", err)
+	}
+
+	for sha, path := range f.layersMap {
+		newPath := filepath.Join(f.layerDir, filepath.Base(path))
+		f.copyLayer(path, newPath)
+		f.layersMap[sha] = newPath
+	}
+
+	for i := range f.layers {
+		layerPath := f.layers[i]
+		f.layers[i] = filepath.Join(f.layerDir, filepath.Base(layerPath))
+	}
+
 	return "saved-digest-from-fake-run-image", nil
+}
+
+func (f *Image) copyLayer(path, newPath string) {
+	src, err := os.Open(path)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	defer src.Close()
+
+	dst, err := os.Create(newPath)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	defer dst.Close()
+
+	if _, err := io.Copy(dst, src); err != nil {
+		f.t.Fatal(err)
+	}
 }
 
 func (f *Image) Delete() error {
@@ -167,6 +204,12 @@ func (f *Image) Found() (bool, error) {
 }
 
 // test methods
+
+func (f *Image) Cleanup() {
+	if err := os.RemoveAll(f.layerDir); err != nil {
+		f.t.Fatal(err)
+	}
+}
 
 func (f *Image) AppLayerPath() string {
 	return f.layers[0]


### PR DESCRIPTION
- Copy all layers on save to a temp dir to mimic the
  actual behavior of an image
- Add cleanup method to clean up the temp dir

Signed-off-by: Danny Joyce <djoyce@pivotal.io>
Signed-off-by: Emily Casey <ecasey@pivotal.io>