### PR TITLE
Added an int to test label metadata to check how the Analyzer decodes it

### DIFF
--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -85,6 +85,7 @@ func testAnalyzer(t *testing.T, when spec.G, it spec.S) {
       "layers": {
         "valid-launch": {
           "data": {
+            "aInt": 11,
             "akey": "avalue",
             "bkey": "bvalue"
           },
@@ -146,6 +147,7 @@ func testAnalyzer(t *testing.T, when spec.G, it spec.S) {
 
 					for _, data := range []struct{ name, expected string }{
 						{"metdata.buildpack/valid-launch.toml", `[metadata]
+  aInt = 11
   akey = "avalue"
   bkey = "bvalue"`},
 						{"metdata.buildpack/stale-launch.toml", `[metadata]
@@ -233,6 +235,7 @@ func testAnalyzer(t *testing.T, when spec.G, it spec.S) {
 						} else {
 							expected := `
 [metadata]
+  aInt = 11
   akey = "avalue"
   bkey = "bvalue"
 `


### PR DESCRIPTION
This test captures a failing scenario where TOML->JSON->TOML is lossy. An int is convert to a float, and can't be coerced back into an int. I figured we should capture this some how.