### PR TITLE
Exporter defaults to `stack.toml` run image

### DIFF
--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -51,8 +50,7 @@ func main() {
 
 	flag.Parse()
 	if flag.NArg() > 1 || flag.Arg(0) == "" {
-		args := map[string]interface{}{"narg": flag.NArg(), "layersDir": layersDir}
-		cmd.Exit(cmd.FailCode(cmd.CodeInvalidArgs, "parse arguments", fmt.Sprintf("%+v", args)))
+		cmd.Exit(cmd.FailCode(cmd.CodeInvalidArgs, "parse arguments"))
 	}
 	repoName = flag.Arg(0)
 	cmd.Exit(export())
@@ -91,8 +89,9 @@ func export() error {
 
 	if runImageRef == "" {
 		if stack.RunImage.Image == "" {
-			return cmd.FailCode(cmd.CodeInvalidArgs, "--run-image is required when stack.toml is not present in builder")
+			return cmd.FailCode(cmd.CodeInvalidArgs, "-image is required when there is no stack metadata available")
 		}
+
 		runImageRef = stack.RunImage.Image
 	}
 

--- a/image/image.go
+++ b/image/image.go
@@ -1,0 +1,32 @@
+package image
+
+import (
+	"errors"
+
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+func ByRegistry(registry string, images []string) (string, error) {
+	if len(images) < 1 {
+		return "", errors.New("no images provided to search")
+	}
+
+	for _, img := range images {
+		reg, err := ParseRegistry(img)
+		if err != nil {
+			continue
+		}
+		if registry == reg {
+			return img, nil
+		}
+	}
+	return images[0], nil
+}
+
+func ParseRegistry(imageName string) (string, error) {
+	ref, err := name.ParseReference(imageName, name.WeakValidation)
+	if err != nil {
+		return "", err
+	}
+	return ref.Context().RegistryStr(), nil
+}

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -1,0 +1,72 @@
+package image_test
+
+import (
+	"testing"
+
+	"github.com/sclevine/spec"
+
+	"github.com/buildpack/lifecycle/image"
+	h "github.com/buildpack/lifecycle/testhelpers"
+)
+
+func TestImage(t *testing.T) {
+	spec.Run(t, "Test Image", testImage)
+}
+
+func testImage(t *testing.T, when spec.G, it spec.S) {
+	when("ByRegistry", func() {
+		var images []string
+		it.Before(func() {
+			images = []string{
+				"first.com/org/repo",
+				"myorg/myrepo",
+				"zonal.gcr.io/org/repo",
+				"gcr.io/org/repo",
+			}
+		})
+
+		when("repoName is dockerhub", func() {
+			it("returns the dockerhub image", func() {
+				name, err := image.ByRegistry("index.docker.io", images)
+				h.AssertNil(t, err)
+				h.AssertEq(t, name, "myorg/myrepo")
+			})
+		})
+
+		when("registry is gcr.io", func() {
+			it("returns the gcr.io image", func() {
+				name, err := image.ByRegistry("gcr.io", images)
+				h.AssertNil(t, err)
+				h.AssertEq(t, name, "gcr.io/org/repo")
+			})
+
+			when("registry is zonal.gcr.io", func() {
+				it("returns the gcr image", func() {
+					name, err := image.ByRegistry("zonal.gcr.io", images)
+					h.AssertNil(t, err)
+					h.AssertEq(t, name, "zonal.gcr.io/org/repo")
+				})
+			})
+
+			when("registry is missingzone.gcr.io", func() {
+				it("returns first run image", func() {
+					name, err := image.ByRegistry("missingzone.gcr.io", images)
+					h.AssertNil(t, err)
+					h.AssertEq(t, name, "first.com/org/repo")
+				})
+			})
+		})
+
+		when("one of the images is non-parsable", func() {
+			it.Before(func() {
+				images = []string{"as@ohd@as@op", "gcr.io/myorg/myrepo"}
+			})
+
+			it("skips over it", func() {
+				name, err := image.ByRegistry("gcr.io", images)
+				h.AssertNil(t, err)
+				h.AssertEq(t, name, "gcr.io/myorg/myrepo")
+			})
+		})
+	})
+}


### PR DESCRIPTION
Remove the required `--image` command line argument and default
to `stack.toml` configuration.
When the argument is passed it overrides the `stack.toml` value

Fixes #119 