### PR TITLE
Show group detection conditions first

### DIFF
--- a/detector.go
+++ b/detector.go
@@ -116,17 +116,17 @@ func (bg *BuildpackGroup) Detect(c *DetectConfig) (plan []byte, group *Buildpack
 		optional := bg.Buildpacks[i].Optional
 		switch code {
 		case CodeDetectPass:
-			c.Out.Printf("%s: pass", name)
+			c.Out.Printf("pass: %s", name)
 			group.Buildpacks = append(group.Buildpacks, bg.Buildpacks[i])
 		case CodeDetectFail:
 			if optional {
-				c.Out.Printf("%s: skip", name)
+				c.Out.Printf("skip: %s", name)
 			} else {
-				c.Out.Printf("%s: fail", name)
+				c.Out.Printf("fail: %s", name)
 			}
 			detected = detected && optional
 		default:
-			c.Out.Printf("%s: error (%d)", name, code)
+			c.Out.Printf("err:  %s: (%d)", name, code)
 			detected = detected && optional
 		}
 	}

--- a/detector_test.go
+++ b/detector_test.go
@@ -113,7 +113,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 				"======== Output: buildpack4-name ========\n"+
 					"stdout: 4\nstderr: 4\n"+
 					"======== Results ========\n"+
-					"buildpack1-name: pass\nbuildpack2-name: pass\nbuildpack3-name: pass\nbuildpack4-name: skip\n",
+					"pass: buildpack1-name\npass: buildpack2-name\npass: buildpack3-name\nskip: buildpack4-name\n",
 			) {
 				t.Fatalf("Unexpected log: %s\n", outLog)
 			}
@@ -137,7 +137,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 				"======== Output: buildpack2-name ========\n"+
 					"stdout: 1\nstderr: 1\n"+
 					"======== Results ========\n"+
-					"buildpack1-name: fail\nbuildpack2-name: fail\n",
+					"fail: buildpack1-name\nfail: buildpack2-name\n",
 			) {
 				t.Fatalf("Unexpected log: %s\n", outLog)
 			}
@@ -161,7 +161,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 				"======== Output: buildpack2-name ========\n"+
 					"stdout: 1\nstderr: 1\n"+
 					"======== Results ========\n"+
-					"buildpack1-name: error (1)\nbuildpack2-name: error (1)\n",
+					"err:  buildpack1-name: (1)\nerr:  buildpack2-name: (1)\n",
 			) {
 				t.Fatalf("Unexpected log: %s\n", outLog)
 			}


### PR DESCRIPTION
Currently, when outputting from group detection, the name of the buildpack is displayed ahead of the condition. For example:

```
  Buildpack-1: pass
  Buildpack-with-longer-name: pass
  BP-short: fail
```

As the example shows, conditions are not vertically aligned. This makes it harder to visually scan for 'pass', 'fail' etc. It also makes it harder to write scripts that automatically parse lifecycle output.

This commit puts the conditions ahead of the buildpack name:

```
  pass: Buildpack-1
  pass: Buildpack-with-longer-name
  fail: BP-short
```

(This PR replaces the pig's breakfast that I and git-duet created in #133)