### PR TITLE
Fixes buildpack/pack#198

### DIFF
--- a/layers.go
+++ b/layers.go
@@ -40,7 +40,7 @@ func readBuildpackLayersDir(layersDir string, buildpack Buildpack) (bpLayersDir,
 
 	tomls, err := filepath.Glob(filepath.Join(path, "*.toml"))
 	for _, toml := range tomls {
-		name := strings.TrimRight(filepath.Base(toml), ".toml")
+		name := strings.TrimSuffix(filepath.Base(toml), ".toml")
 		bpDir.layers[name] = *bpDir.newBPLayer(name)
 	}
 	return bpDir, nil


### PR DESCRIPTION
* replaces incorrect TrimRight with TrimSuffix when deriving layer naames from metadata files during export

Signed-off-by: Emily Casey <ecasey@pivotal.io>