### PR TITLE
Add support for scratch containers

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -29,8 +29,9 @@ type BuildEnv interface {
 }
 
 type Process struct {
-	Type    string `toml:"type"`
-	Command string `toml:"command"`
+	Type    string   `toml:"type"`
+	Command string   `toml:"command"`
+	Args    []string `toml:"args"`
 }
 
 type LaunchTOML struct {

--- a/builder.go
+++ b/builder.go
@@ -32,6 +32,7 @@ type Process struct {
 	Type    string   `toml:"type"`
 	Command string   `toml:"command"`
 	Args    []string `toml:"args"`
+	Direct  bool     `toml:"direct"`
 }
 
 type LaunchTOML struct {

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"strings"
 	"syscall"
 
 	"github.com/BurntSushi/toml"
@@ -65,7 +64,7 @@ func launch() error {
 		Exec:               syscall.Exec,
 	}
 
-	if err := launcher.Launch(os.Args[0], strings.Join(os.Args[1:], " ")); err != nil {
+	if err := launcher.Launch(os.Args[0], os.Args[1:]); err != nil {
 		return cmd.FailErrCode(err, cmd.CodeFailedLaunch, "launch")
 	}
 	return nil

--- a/launcher.go
+++ b/launcher.go
@@ -148,7 +148,7 @@ func (l *Launcher) processFor(cmd []string) (Process, error) {
 		}
 	}
 
-	if len(cmd) > 1 && cmd[0] == "-" {
+	if len(cmd) > 1 && cmd[0] == "--" {
 		return Process{Command: cmd[1], Args: cmd[2:], Direct: true}, nil
 	}
 

--- a/launcher_test.go
+++ b/launcher_test.go
@@ -187,7 +187,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("should invoke a provided start command directly", func() {
-				if err := launcher.Launch("/path/to/launcher", []string{"-", "sh", "arg1", "arg2"}); err != nil {
+				if err := launcher.Launch("/path/to/launcher", []string{"--", "sh", "arg1", "arg2"}); err != nil {
 					t.Fatal(err)
 				}
 

--- a/launcher_test.go
+++ b/launcher_test.go
@@ -86,7 +86,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 	when("#Launch", func() {
 		when("no start command has been specified", func() {
 			it("should run the default process type", func() {
-				if err := launcher.Launch("/path/to/launcher", ""); err != nil {
+				if err := launcher.Launch("/path/to/launcher", nil); err != nil {
 					t.Fatal(err)
 				}
 
@@ -110,7 +110,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 				it("should return an error", func() {
 					launcher.DefaultProcessType = "not-exist"
 
-					if err := launcher.Launch("/path/to/launcher", ""); err == nil {
+					if err := launcher.Launch("/path/to/launcher", nil); err == nil {
 						t.Fatal("expected launch to return an error")
 					}
 
@@ -124,7 +124,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 		when("start command has been specified", func() {
 			when("start command matches a process type", func() {
 				it("should run that process type", func() {
-					if err := launcher.Launch("/path/to/launcher", "worker"); err != nil {
+					if err := launcher.Launch("/path/to/launcher", []string{"worker"}); err != nil {
 						t.Fatal(err)
 					}
 
@@ -140,7 +140,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 
 			when("start command does NOT match a process type", func() {
 				it("should run the start command", func() {
-					if err := launcher.Launch("/path/to/launcher", "some-different-process"); err != nil {
+					if err := launcher.Launch("/path/to/launcher", []string{"some-different-process"}); err != nil {
 						t.Fatal(err)
 					}
 
@@ -156,8 +156,29 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("a start command provides a list of arguments", func() {
-			it("should invoke the command directly", func() {
-				if err := launcher.Launch("/path/to/launcher", "direct"); err != nil {
+			it("should invoke a process type's start command directly", func() {
+				if err := launcher.Launch("/path/to/launcher", []string{"direct"}); err != nil {
+					t.Fatal(err)
+				}
+
+				if len(syscallExecArgsColl) != 1 {
+					t.Fatalf("expected syscall.Exec to be called once: actual %v\n", syscallExecArgsColl)
+				}
+
+				if diff := cmp.Diff(syscallExecArgsColl[0].argv0, "/bin/sh"); diff != "" {
+					t.Fatalf("syscall.Exec Argv did not match: (-got +want)\n%s\n", diff)
+				}
+
+				if diff := cmp.Diff(syscallExecArgsColl[0].argv[0], "sh"); diff != "" {
+					t.Fatalf("syscall.Exec Argv did not match: (-got +want)\n%s\n", diff)
+				}
+				if diff := cmp.Diff(syscallExecArgsColl[0].argv[1], "some-arg"); diff != "" {
+					t.Fatalf("syscall.Exec Argv did not match: (-got +want)\n%s\n", diff)
+				}
+			})
+
+			it("should invoke a provided start command directly", func() {
+				if err := launcher.Launch("/path/to/launcher", []string{"sh", "some-arg"}); err != nil {
 					t.Fatal(err)
 				}
 
@@ -179,7 +200,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 
 			when("the list of arguments is empty", func() {
 				it("should invoke the command directly without arguments", func() {
-					if err := launcher.Launch("/path/to/launcher", "direct-empty"); err != nil {
+					if err := launcher.Launch("/path/to/launcher", []string{"direct-empty"}); err != nil {
 						t.Fatal(err)
 					}
 
@@ -234,7 +255,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 					env.EXPECT().AddEnvDir(filepath.Join(tmpDir, "launch", "bp.2", "layer4", "env")),
 					env.EXPECT().AddEnvDir(filepath.Join(tmpDir, "launch", "bp.2", "layer4", "env.launch")),
 				)
-				if err := launcher.Launch("/path/to/launcher", "start"); err != nil {
+				if err := launcher.Launch("/path/to/launcher", []string{"start"}); err != nil {
 					t.Fatal(err)
 				}
 				stdout := rdfile(t, filepath.Join(tmpDir, "stdout"))
@@ -254,7 +275,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("ignores those buildpacks when setting the env", func() {
-				if err := launcher.Launch("/path/to/launcher", "start"); err != nil {
+				if err := launcher.Launch("/path/to/launcher", []string{"start"}); err != nil {
 					t.Fatal(err)
 				}
 				if len(syscallExecArgsColl) != 1 {
@@ -287,7 +308,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("should run them in buildpack order", func() {
-				if err := launcher.Launch("/path/to/launcher", "start"); err != nil {
+				if err := launcher.Launch("/path/to/launcher", []string{"start"}); err != nil {
 					t.Fatal(err)
 				}
 
@@ -307,7 +328,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				it("should run them in buildpack order", func() {
-					if err := launcher.Launch("/path/to/launcher", "start"); err != nil {
+					if err := launcher.Launch("/path/to/launcher", []string{"start"}); err != nil {
 						t.Fatal(err)
 					}
 
@@ -330,7 +351,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				it("should source .profile", func() {
-					if err := launcher.Launch("/path/to/launcher", "start"); err != nil {
+					if err := launcher.Launch("/path/to/launcher", []string{"start"}); err != nil {
 						t.Fatal(err)
 					}
 


### PR DESCRIPTION
Allow buildpacks to provide `args` that trigger bash-free mode for a given process type.
App developers can use `CMD` with more than one argument to trigger bash-free mode for custom start commands..

Skips profile.d and .profile in bash-free mode.

Spec PR: https://github.com/buildpack/spec/pull/50
