### PR TITLE
Update image cache to save images in a remote repository.

### DIFF
--- a/cmd/cacher/main.go
+++ b/cmd/cacher/main.go
@@ -8,7 +8,6 @@ import (
 	"os"
 
 	"github.com/BurntSushi/toml"
-
 	"github.com/buildpack/imgutil/remote"
 
 	"github.com/buildpack/lifecycle"

--- a/cmd/restorer/main.go
+++ b/cmd/restorer/main.go
@@ -8,12 +8,13 @@ import (
 	"os"
 
 	"github.com/BurntSushi/toml"
-	"github.com/buildpack/imgutil/local"
+
+	"github.com/buildpack/imgutil/remote"
 
 	"github.com/buildpack/lifecycle"
 	"github.com/buildpack/lifecycle/cache"
 	"github.com/buildpack/lifecycle/cmd"
-	"github.com/buildpack/lifecycle/docker"
+	"github.com/buildpack/lifecycle/image/auth"
 )
 
 var (
@@ -72,17 +73,24 @@ func restore() error {
 
 	var cacheStore lifecycle.Cache
 	if cacheImageTag != "" {
-		dockerClient, err := docker.DefaultClient()
+		origCacheImage, err := remote.NewImage(
+			cacheImageTag,
+			auth.DefaultEnvKeychain(),
+			remote.FromBaseImage(cacheImageTag),
+		)
 		if err != nil {
-			return cmd.FailErr(err, "create docker client")
+			return cmd.FailErr(err, "accessing cache image")
 		}
 
-		origCacheImage, err := local.NewImage(cacheImageTag, dockerClient, local.FromBaseImage(cacheImageTag))
+		emptyImage, err := remote.NewImage(
+			cacheImageTag,
+			auth.DefaultEnvKeychain(),
+			remote.WithPreviousImage(cacheImageTag),
+		)
 		if err != nil {
-			return cmd.FailErr(err, "access cache image")
+			return cmd.FailErr(err, "creating empty image")
 		}
 
-		emptyImage, err := local.NewImage(cacheImageTag, dockerClient, local.WithPreviousImage(cacheImageTag))
 		cacheStore = cache.NewImageCache(
 			origCacheImage,
 			emptyImage,

--- a/cmd/restorer/main.go
+++ b/cmd/restorer/main.go
@@ -8,7 +8,6 @@ import (
 	"os"
 
 	"github.com/BurntSushi/toml"
-
 	"github.com/buildpack/imgutil/remote"
 
 	"github.com/buildpack/lifecycle"

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/buildpack/lifecycle
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/buildpack/imgutil v0.0.0-20190702194220-aa6eb76474d3
+	github.com/buildpack/imgutil v0.0.0-20190726132853-1f31ed20483a
 	github.com/docker/docker v0.7.3-0.20190307005417-54dddadc7d5d
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/Microsoft/go-winio v0.4.12 h1:xAfWHN1IrQ0NJ9TBC0KBZoqLjzDTr1ML+4MywiU
 github.com/Microsoft/go-winio v0.4.12/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/buildpack/imgutil v0.0.0-20190702194220-aa6eb76474d3 h1:aSZAFY7Fux4lds6QQwN13SuzJFF7iUe1T0JkO7HLnAA=
 github.com/buildpack/imgutil v0.0.0-20190702194220-aa6eb76474d3/go.mod h1:X0yFLGZtSyTXsEJq9NaPP9Rdnaq+3wouZ7xaTgw1680=
+github.com/buildpack/imgutil v0.0.0-20190726132853-1f31ed20483a h1:N9h8e7nYvJKpfQdEGU3RK/xSLXIuhPQURH0g3KIGgM0=
+github.com/buildpack/imgutil v0.0.0-20190726132853-1f31ed20483a/go.mod h1:X0yFLGZtSyTXsEJq9NaPP9Rdnaq+3wouZ7xaTgw1680=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/vendor/github.com/buildpack/imgutil/remote/remote.go
+++ b/vendor/github.com/buildpack/imgutil/remote/remote.go
@@ -296,7 +296,7 @@ func (i *Image) GetLayer(sha string) (io.ReadCloser, error) {
 		return nil, err
 	}
 
-	return layer.Compressed()
+	return layer.Uncompressed()
 }
 
 func (i *Image) AddLayer(path string) error {
@@ -361,16 +361,19 @@ func (i *Image) doSave(imageName string) error {
 	if err != nil {
 		return err
 	}
-
-	if err := remote.Write(ref, i.image, remote.WithAuth(auth)); err != nil {
-		return err
-	}
-
-	return nil
+	return remote.Write(ref, i.image, remote.WithAuth(auth))
 }
 
 func (i *Image) Delete() error {
-	return errors.New("remote image does not implement Delete")
+	id, err := i.Identifier()
+	if err != nil {
+		return err
+	}
+	ref, auth, err := referenceForRepoName(i.keychain, id.String())
+	if err != nil {
+		return err
+	}
+	return remote.Delete(ref, remote.WithAuth(auth))
 }
 
 type subImage struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2,7 +2,7 @@
 github.com/BurntSushi/toml
 # github.com/Microsoft/go-winio v0.4.12
 github.com/Microsoft/go-winio
-# github.com/buildpack/imgutil v0.0.0-20190702194220-aa6eb76474d3
+# github.com/buildpack/imgutil v0.0.0-20190726132853-1f31ed20483a
 github.com/buildpack/imgutil
 github.com/buildpack/imgutil/local
 github.com/buildpack/imgutil/remote


### PR DESCRIPTION
Switch cacher and restorer to use imgutil remote instead of local.
Make deleting the old cache image optional in image_cache commit.

This change depends on https://github.com/buildpack/imgutil/pull/10.