### PR TITLE
rename providers to provides

### DIFF
--- a/detector.go
+++ b/detector.go
@@ -45,7 +45,7 @@ type BuildPlan struct {
 }
 
 type BuildPlanEntry struct {
-	Providers []Buildpack `toml:"providers"`
+	Providers []Buildpack `toml:"provides"`
 	Requires  []Require   `toml:"requires"`
 }
 


### PR DESCRIPTION
Hi guys!
According to the specs, the correct spelling should be `provided`, not `providers`.
https://github.com/buildpack/spec/blob/master/buildpack.md#build-plan-toml