### PR TITLE
Make lifecycle package's nested directory consistent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,13 +25,13 @@ all: test build package
 build:
 	@echo "> Building lifecycle..."
 	mkdir -p ./out/$(ARCHIVE_NAME)
-	$(GOENV) $(GOBUILD) -o ./out/$(ARCHIVE_NAME)/detector -a ./cmd/detector
-	$(GOENV) $(GOBUILD) -o ./out/$(ARCHIVE_NAME)/restorer -a ./cmd/restorer
-	$(GOENV) $(GOBUILD) -o ./out/$(ARCHIVE_NAME)/analyzer -a ./cmd/analyzer
-	$(GOENV) $(GOBUILD) -o ./out/$(ARCHIVE_NAME)/builder -a ./cmd/builder
-	$(GOENV) $(GOBUILD) -o ./out/$(ARCHIVE_NAME)/exporter -a ./cmd/exporter
-	$(GOENV) $(GOBUILD) -o ./out/$(ARCHIVE_NAME)/cacher -a ./cmd/cacher
-	$(GOENV) $(GOBUILD) -o ./out/$(ARCHIVE_NAME)/launcher -a ./cmd/launcher
+	$(GOENV) $(GOBUILD) -o ./out/lifecycle/detector -a ./cmd/detector
+	$(GOENV) $(GOBUILD) -o ./out/lifecycle/restorer -a ./cmd/restorer
+	$(GOENV) $(GOBUILD) -o ./out/lifecycle/analyzer -a ./cmd/analyzer
+	$(GOENV) $(GOBUILD) -o ./out/lifecycle/builder -a ./cmd/builder
+	$(GOENV) $(GOBUILD) -o ./out/lifecycle/exporter -a ./cmd/exporter
+	$(GOENV) $(GOBUILD) -o ./out/lifecycle/cacher -a ./cmd/cacher
+	$(GOENV) $(GOBUILD) -o ./out/lifecycle/launcher -a ./cmd/launcher
 
 descriptor: export LIFECYCLE_DESCRIPTOR:=$(LIFECYCLE_DESCRIPTOR)
 descriptor:
@@ -80,4 +80,4 @@ clean:
 
 package: descriptor
 	@echo "> Packaging lifecycle..."
-	tar czf ./out/$(ARCHIVE_NAME).tgz -C out $(ARCHIVE_NAME) lifecycle.toml
+	tar czf ./out/$(ARCHIVE_NAME).tgz -C out lifecycle.toml lifecycle

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ make all
 ```
 This will create an archive at `out/lifecycle-<LIFECYCLE_VERSION>+linux.x86-64.tgz`.
 
-By default, `LIFECYCLE_VERSION` is `dev`. It can be changed by prepending `LIFECYCLE_VERSION=<some version>` to the
+By default, `LIFECYCLE_VERSION` is `0.0.0`. It can be changed by prepending `LIFECYCLE_VERSION=<some version>` to the
 `make` command. For example:
 
 ```bash
@@ -58,7 +58,7 @@ $ make test
 
 ### Build
 
-Builds binaries to `out/lifecycle-<LIFECYCLE_VERSION>+linux.x86-64/` for the given (or default) `LIFECYCLE_VERSION`.
+Builds binaries to `out/lifecycle/`.
 
 ```bash
 $ make build
@@ -69,7 +69,7 @@ $ make build
 ### Package
 
 Creates an archive at `out/lifecycle-<LIFECYCLE_VERSION>+linux.x86-64.tgz`, using the contents of the
-`out/lifecycle-<LIFECYCLE_VERSION>+linux.x86-64/` directory, for the given (or default) `LIFECYCLE_VERSION`.
+`out/lifecycle/` directory, for the given (or default) `LIFECYCLE_VERSION`.
 
 ```bash
 $ make package


### PR DESCRIPTION
Based on conversations with @sclevine, it makes sense to have a consistent nested directory structure in order to make validating and detecting lifecycle binaries/descriptors programmatically.

The new structure is now always the following regardless of version:

```
lifecycle.toml
lifecycle/
lifecycle/launcher
lifecycle/detector
lifecycle/exporter
lifecycle/builder
lifecycle/cacher
lifecycle/analyzer
lifecycle/restorer
```

Signed-off-by: Javier Romero <jromero@pivotal.io>