### PR TITLE
Truncate SHAs when displaying them

### DIFF
--- a/cacher.go
+++ b/cacher.go
@@ -80,10 +80,10 @@ func (c *Cacher) addOrReuseLayer(cache Cache, layer bpLayer, previousSHA string)
 	}
 
 	if sha == previousSHA {
-		c.Out.Printf("Reusing layer '%s' with SHA %s\n", layer.Identifier(), sha)
+		c.Out.Printf("Reusing layer '%s' with SHA %s\n", layer.Identifier(), DisplaySha(sha))
 		return sha, cache.ReuseLayer(previousSHA)
 	}
 
-	c.Out.Printf("Caching layer '%s' with SHA %s\n", layer.Identifier(), sha)
+	c.Out.Printf("Caching layer '%s' with SHA %s\n", layer.Identifier(), DisplaySha(sha))
 	return sha, cache.AddLayerFile(sha, tarPath)
 }

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -144,7 +144,7 @@ func export() error {
 		}
 
 		if analyzedMD.Image != nil {
-			cmd.OutLogger.Printf("Reusing layers from image with id '%s'", analyzedMD.Image.Reference)
+			cmd.OutLogger.Printf("Reusing layers from image with id %s", lifecycle.DisplaySha(analyzedMD.Image.Reference))
 			opts = append(opts, local.WithPreviousImage(analyzedMD.Image.Reference))
 		}
 

--- a/exporter.go
+++ b/exporter.go
@@ -99,7 +99,7 @@ func (e *Exporter) Export(
 					return fmt.Errorf("cannot reuse '%s', previous image has no metadata for layer '%s'", layer.Identifier(), layer.Identifier())
 				}
 
-				e.Out.Printf("Reusing layer '%s' with SHA %s\n", layer.Identifier(), origLayerMetadata.SHA)
+				e.Out.Printf("Reusing layer '%s' with SHA %s\n", layer.Identifier(), DisplaySha(origLayerMetadata.SHA))
 				if err := workingImage.ReuseLayer(origLayerMetadata.SHA); err != nil {
 					return errors.Wrapf(err, "reusing layer: '%s'", layer.Identifier())
 				}
@@ -163,10 +163,10 @@ func (e *Exporter) addLayer(image imgutil.Image, layer identifiableLayer, previo
 		return "", errors.Wrapf(err, "exporting layer '%s'", layer.Identifier())
 	}
 	if sha == previousSHA {
-		e.Out.Printf("Reusing layer '%s' with SHA %s\n", layer.Identifier(), sha)
+		e.Out.Printf("Reusing layer '%s' with SHA %s\n", layer.Identifier(), DisplaySha(sha))
 		return sha, image.ReuseLayer(previousSHA)
 	}
-	e.Out.Printf("Exporting layer '%s' with SHA %s\n", layer.Identifier(), sha)
+	e.Out.Printf("Exporting layer '%s' with SHA %s\n", layer.Identifier(), DisplaySha(sha))
 	return sha, image.AddLayer(tarPath)
 }
 
@@ -224,7 +224,7 @@ func (e *Exporter) saveImage(image imgutil.Image, additionalNames []string) erro
 func (e *Exporter) logReference(identifier imgutil.Identifier) {
 	switch v := identifier.(type) {
 	case local.IDIdentifier:
-		e.Out.Printf("\n*** Image ID: %s\n", v.String())
+		e.Out.Printf("\n*** Image ID: %s\n", DisplaySha(v.String()))
 	case remote.DigestIdentifier:
 		e.Out.Printf("\n*** Digest: %s\n", v.Digest.DigestStr())
 	default:

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -199,7 +199,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 				launcherLayerSHA := h.ComputeSHA256ForPath(t, launcherConfig.Path, uid, gid)
 				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, fakeImageMetadata, additionalNames, launcherConfig, stack))
 				h.AssertContains(t, fakeAppImage.ReusedLayers(), "sha256:"+launcherLayerSHA)
-				assertReuseLayerLog(t, stdout, "launcher", launcherLayerSHA)
+				assertReuseLayerLog(t, stdout, "launcher", lifecycle.DisplaySha(launcherLayerSHA))
 			})
 
 			it("reuses launch layers when only layer.toml is present", func() {
@@ -560,7 +560,7 @@ type = "Apache-2.0"
 
 					h.AssertStringContains(t,
 						stdout.String(),
-						`*** Image ID: some-image-id`,
+						`*** Image ID: some-image-`,
 					)
 				})
 			})
@@ -607,7 +607,7 @@ type = "Apache-2.0"
       %s - succeeded
       %s - could not parse reference
 
-*** Image ID: some-image-id`,
+*** Image ID: some-image-`,
 							fakeAppImage.Name(),
 							additionalNames[0],
 							additionalNames[1],
@@ -974,13 +974,13 @@ func assertAddLayerLog(t *testing.T, stdout bytes.Buffer, name, layerPath string
 	t.Helper()
 	layerSHA := h.ComputeSHA256ForFile(t, layerPath)
 
-	expected := fmt.Sprintf("Exporting layer '%s' with SHA sha256:%s", name, layerSHA)
+	expected := fmt.Sprintf("Exporting layer '%s' with SHA %s", name, lifecycle.DisplaySha(layerSHA))
 	h.AssertStringContains(t, stdout.String(), expected)
 }
 
 func assertReuseLayerLog(t *testing.T, stdout bytes.Buffer, name, sha string) {
 	t.Helper()
-	expected := fmt.Sprintf("Reusing layer '%s' with SHA sha256:%s", name, sha)
+	expected := fmt.Sprintf("Reusing layer '%s' with SHA %s", name, lifecycle.DisplaySha(sha))
 	h.AssertStringContains(t, stdout.String(), expected)
 }
 

--- a/utils.go
+++ b/utils.go
@@ -34,6 +34,14 @@ func ReadOrder(path string) (BuildpackOrder, error) {
 	return order.Order, err
 }
 
+func DisplaySha(sha string) string {
+	rawSha := strings.TrimPrefix(sha, "sha256:")
+	if len(sha) > 12 {
+		return rawSha[0:12]
+	}
+	return rawSha
+}
+
 func escapeID(id string) string {
 	return strings.Replace(id, "/", "_", -1)
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -118,4 +118,29 @@ func testUtils(t *testing.T, when spec.G, it spec.S) {
 			}
 		})
 	})
+
+	when(".DisplaySha", func() {
+		it("should truncate the sha", func() {
+			actual := lifecycle.DisplaySha("ed649d0a36b218c476b64d61f85027477ef5742045799f45c8c353562279065a")
+			if s := cmp.Diff(actual, "ed649d0a36b2"); s != "" {
+				t.Fatalf("Unexpected sha:\n%s\n", s)
+			}
+		})
+
+		it("should not truncate the sha with it's short", func() {
+			sha := "not-a-sha"
+			actual := lifecycle.DisplaySha(sha)
+			if s := cmp.Diff(actual, sha); s != "" {
+				t.Fatalf("Unexpected sha:\n%s\n", s)
+			}
+		})
+
+		it("should remove the prefix", func() {
+			sha := "sha256:ed649d0a36b218c476b64d61f85027477ef5742045799f45c8c353562279065a"
+			actual := lifecycle.DisplaySha(sha)
+			if s := cmp.Diff(actual, "ed649d0a36b2"); s != "" {
+				t.Fatalf("Unexpected sha:\n%s\n", s)
+			}
+		})
+	})
 }


### PR DESCRIPTION
This adds a util function that will truncate SHAs and remove the `sha256:` prefix. This is similar to what commands like `docker ps` and `docker images` do, where they truncate the sha to 12 characters.

We might also add `--no-trunc` option as with the [docker commands](https://docs.docker.com/engine/reference/commandline/ps/).

Alternatively, we could remove the SHAs from the logs entirely, and only show them when a verbose flag is passed.

End result looks like:

```
[exporter] Reusing layers from image with id 32c0a8586f36
[exporter] Exporting layer 'app' with SHA 75b3f03ac61d
[exporter] Reusing layer 'config' with SHA 227f48eccef2
[exporter] Exporting layer 'launcher' with SHA 942ac40d4b66
[exporter] Reusing layer 'heroku/java:jre' with SHA 3cec1444bdec
[exporter] *** Images:
[exporter]       index.docker.io/library/myimage:latest - succeeded
[exporter]
[exporter] *** Image ID: ecc176797be5
```