### PR TITLE
Make logs more user friendly

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -104,7 +104,7 @@ func (a *Analyzer) getImageIdentifier(image imgutil.Image) (*metadata.ImageIdent
 	if err != nil {
 		return nil, err
 	}
-	a.Logger.Infof("Analyzing image '%s'", identifier.String())
+	a.Logger.Debugf("Analyzing image '%s'", identifier.String())
 	return &metadata.ImageIdentifier{
 		Reference: identifier.String(),
 	}, nil

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -211,7 +211,7 @@ func Exit(err error) {
 	if err == nil {
 		os.Exit(0)
 	}
-	Logger.Errorf("Error: %s\n", err)
+	Logger.Errorf("%s\n", err)
 	if err, ok := err.(*ErrorFail); ok {
 		os.Exit(err.Code)
 	}

--- a/cmd/detector/main.go
+++ b/cmd/detector/main.go
@@ -80,6 +80,10 @@ func detect() error {
 		Logger:        cmd.Logger,
 	})
 	if err != nil {
+		if err == lifecycle.ErrFail {
+			cmd.Logger.Error("No buildpack groups passed detection.")
+			cmd.Logger.Error("Please check that you are running against the correct path.")
+		}
 		return cmd.FailErrCode(err, cmd.CodeFailedDetect, "detect")
 	}
 

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -148,7 +148,7 @@ func export() error {
 		}
 
 		if analyzedMD.Image != nil {
-			cmd.Logger.Infof("Reusing layers from image with id '%s'", analyzedMD.Image.Reference)
+			cmd.Logger.Debugf("Reusing layers from image with id '%s'", analyzedMD.Image.Reference)
 			opts = append(opts, local.WithPreviousImage(analyzedMD.Image.Reference))
 		}
 

--- a/detector.go
+++ b/detector.go
@@ -21,7 +21,7 @@ const (
 	CodeDetectFail = 100
 )
 
-var ErrFail = errors.New("No buildpack groups passed detection.\nPlease check that you are running against the correct path.")
+var ErrFail = errors.New("no buildpacks participating")
 
 type Buildpack struct {
 	ID       string `toml:"id" json:"id"`

--- a/detector.go
+++ b/detector.go
@@ -19,9 +19,11 @@ import (
 const (
 	CodeDetectPass = 0
 	CodeDetectFail = 100
+
+	DetectFailureMessage = "None of the provided buildpack groups passed detection for this repository.\nPlease check that you are running against the correct path."
 )
 
-var ErrFail = errors.New("detection failed")
+var ErrFail = errors.New("no buildpacks match this repository")
 
 type Buildpack struct {
 	ID       string `toml:"id" json:"id"`
@@ -146,6 +148,7 @@ func (c *DetectConfig) process(done []Buildpack) ([]Buildpack, []BuildPlanEntry,
 		return c.runTrial(i, trial)
 	})
 	if err != nil {
+		c.Logger.Info(DetectFailureMessage)
 		return nil, nil, err
 	}
 

--- a/detector.go
+++ b/detector.go
@@ -169,7 +169,7 @@ func (c *DetectConfig) process(done []Buildpack) ([]Buildpack, []BuildPlanEntry,
 
 	var found []Buildpack
 	for _, r := range trial {
-		c.Logger.Infof("Detected %s", r.Output)
+		c.Logger.Infof("Detected %s", r.Buildpack.ID)
 		found = append(found, r.Buildpack.noOpt())
 	}
 	var plan []BuildPlanEntry
@@ -373,7 +373,7 @@ func (r *detectResult) options() []detectOption {
 	for i, sections := range append([]planSections{r.planSections}, r.Or...) {
 		bp := r.Buildpack
 		bp.Optional = bp.Optional && i == len(r.Or)
-		out = append(out, detectOption{bp, sections, r.Output})
+		out = append(out, detectOption{bp, sections})
 	}
 	return out
 }
@@ -405,7 +405,6 @@ func (rs detectResults) runTrialsFrom(prefix detectTrial, f trialFunc) (depMap, 
 type detectOption struct {
 	Buildpack
 	planSections
-	Output []byte
 }
 
 type detectTrial []detectOption

--- a/detector.go
+++ b/detector.go
@@ -169,7 +169,6 @@ func (c *DetectConfig) process(done []Buildpack) ([]Buildpack, []BuildPlanEntry,
 
 	var found []Buildpack
 	for _, r := range trial {
-		c.Logger.Infof("Detected %s", r.Buildpack.ID)
 		found = append(found, r.Buildpack.noOpt())
 	}
 	var plan []BuildPlanEntry

--- a/detector.go
+++ b/detector.go
@@ -169,6 +169,7 @@ func (c *DetectConfig) process(done []Buildpack) ([]Buildpack, []BuildPlanEntry,
 
 	var found []Buildpack
 	for _, r := range trial {
+		c.Logger.Infof("Detected %s", r.Output)
 		found = append(found, r.Buildpack.noOpt())
 	}
 	var plan []BuildPlanEntry
@@ -372,7 +373,7 @@ func (r *detectResult) options() []detectOption {
 	for i, sections := range append([]planSections{r.planSections}, r.Or...) {
 		bp := r.Buildpack
 		bp.Optional = bp.Optional && i == len(r.Or)
-		out = append(out, detectOption{bp, sections})
+		out = append(out, detectOption{bp, sections, r.Output})
 	}
 	return out
 }
@@ -404,6 +405,7 @@ func (rs detectResults) runTrialsFrom(prefix detectTrial, f trialFunc) (depMap, 
 type detectOption struct {
 	Buildpack
 	planSections
+	Output []byte
 }
 
 type detectTrial []detectOption

--- a/detector.go
+++ b/detector.go
@@ -19,11 +19,9 @@ import (
 const (
 	CodeDetectPass = 0
 	CodeDetectFail = 100
-
-	DetectFailureMessage = "None of the provided buildpack groups passed detection for this repository.\nPlease check that you are running against the correct path."
 )
 
-var ErrFail = errors.New("no buildpacks match this repository")
+var ErrFail = errors.New("No buildpack groups passed detection.\nPlease check that you are running against the correct path.")
 
 type Buildpack struct {
 	ID       string `toml:"id" json:"id"`
@@ -148,7 +146,6 @@ func (c *DetectConfig) process(done []Buildpack) ([]Buildpack, []BuildPlanEntry,
 		return c.runTrial(i, trial)
 	})
 	if err != nil {
-		c.Logger.Info(DetectFailureMessage)
 		return nil, nil, err
 	}
 

--- a/detector_test.go
+++ b/detector_test.go
@@ -135,7 +135,8 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 			if s := cmp.Diff(outLog.String(),
 				"======== Results ========\n"+
 					"Resolving plan... (try #1)\n"+
-					"fail: no viable buildpacks in group\n",
+					"fail: no viable buildpacks in group\n"+
+					lifecycle.DetectFailureMessage+"\n",
 			); s != "" {
 				t.Fatalf("Unexpected log:\n%s\n", s)
 			}
@@ -158,7 +159,8 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					"skip: A@v1\n"+
 					"skip: B@v1\n"+
 					"Resolving plan... (try #1)\n"+
-					"fail: no viable buildpacks in group\n",
+					"fail: no viable buildpacks in group\n"+
+					lifecycle.DetectFailureMessage+"\n",
 			) {
 				t.Fatalf("Unexpected log:\n%s\n", s)
 			}
@@ -280,7 +282,8 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 						"pass: B@v1\n"+
 						"pass: C@v1\n"+
 						"Resolving plan... (try #1)\n"+
-						"fail: B@v1 requires dep1\n",
+						"fail: B@v1 requires dep1\n"+
+						lifecycle.DetectFailureMessage+"\n",
 				) {
 					t.Fatalf("Unexpected log:\n%s\n", s)
 				}
@@ -308,7 +311,8 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 						"pass: B@v1\n"+
 						"skip: C@v1\n"+
 						"Resolving plan... (try #1)\n"+
-						"fail: B@v1 provides unused dep1\n",
+						"fail: B@v1 provides unused dep1\n"+
+						lifecycle.DetectFailureMessage+"\n",
 				) {
 					t.Fatalf("Unexpected log:\n%s\n", s)
 				}

--- a/detector_test.go
+++ b/detector_test.go
@@ -135,8 +135,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 			if s := cmp.Diff(outLog.String(),
 				"======== Results ========\n"+
 					"Resolving plan... (try #1)\n"+
-					"fail: no viable buildpacks in group\n"+
-					lifecycle.DetectFailureMessage+"\n",
+					"fail: no viable buildpacks in group\n",
 			); s != "" {
 				t.Fatalf("Unexpected log:\n%s\n", s)
 			}
@@ -159,8 +158,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					"skip: A@v1\n"+
 					"skip: B@v1\n"+
 					"Resolving plan... (try #1)\n"+
-					"fail: no viable buildpacks in group\n"+
-					lifecycle.DetectFailureMessage+"\n",
+					"fail: no viable buildpacks in group\n",
 			) {
 				t.Fatalf("Unexpected log:\n%s\n", s)
 			}
@@ -282,8 +280,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 						"pass: B@v1\n"+
 						"pass: C@v1\n"+
 						"Resolving plan... (try #1)\n"+
-						"fail: B@v1 requires dep1\n"+
-						lifecycle.DetectFailureMessage+"\n",
+						"fail: B@v1 requires dep1\n",
 				) {
 					t.Fatalf("Unexpected log:\n%s\n", s)
 				}
@@ -311,8 +308,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 						"pass: B@v1\n"+
 						"skip: C@v1\n"+
 						"Resolving plan... (try #1)\n"+
-						"fail: B@v1 provides unused dep1\n"+
-						lifecycle.DetectFailureMessage+"\n",
+						"fail: B@v1 provides unused dep1\n",
 				) {
 					t.Fatalf("Unexpected log:\n%s\n", s)
 				}

--- a/exporter.go
+++ b/exporter.go
@@ -219,7 +219,7 @@ func (e *Exporter) saveImage(image imgutil.Image, additionalNames []string) erro
 	e.Logger.Info("*** Images:")
 	for _, n := range append([]string{image.Name()}, additionalNames...) {
 		if ok, message := getSaveStatus(saveErr, n); !ok {
-			e.Logger.Infof("      %s - %s\n", n, TruncateSha(ref), message)
+			e.Logger.Infof("      %s - %s\n", n, message)
 		} else {
 			e.Logger.Infof("      %s (%s)\n", n, TruncateSha(ref))
 		}

--- a/exporter.go
+++ b/exporter.go
@@ -224,11 +224,11 @@ func (e *Exporter) saveImage(image imgutil.Image, additionalNames []string) erro
 func (e *Exporter) logReference(identifier imgutil.Identifier) {
 	switch v := identifier.(type) {
 	case local.IDIdentifier:
-		e.Logger.Infof("\n*** Image ID: %s\n", v.String())
+		e.Logger.Debugf("\n*** Image ID: %s\n", v.String())
 	case remote.DigestIdentifier:
-		e.Logger.Infof("\n*** Digest: %s\n", v.Digest.DigestStr())
+		e.Logger.Debugf("\n*** Digest: %s\n", v.Digest.DigestStr())
 	default:
-		e.Logger.Infof("\n*** Reference: %s\n", v.String())
+		e.Logger.Debugf("\n*** Reference: %s\n", v.String())
 	}
 }
 

--- a/exporter.go
+++ b/exporter.go
@@ -99,7 +99,8 @@ func (e *Exporter) Export(
 					return fmt.Errorf("cannot reuse '%s', previous image has no metadata for layer '%s'", layer.Identifier(), layer.Identifier())
 				}
 
-				e.Logger.Debugf("Reusing layer '%s' with SHA %s\n", layer.Identifier(), origLayerMetadata.SHA)
+				e.Logger.Infof("Reusing layer '%s'\n", layer.Identifier())
+				e.Logger.Debugf("Layer '%s' SHA: %s\n", layer.Identifier(), origLayerMetadata.SHA)
 				if err := workingImage.ReuseLayer(origLayerMetadata.SHA); err != nil {
 					return errors.Wrapf(err, "reusing layer: '%s'", layer.Identifier())
 				}
@@ -163,10 +164,12 @@ func (e *Exporter) addLayer(image imgutil.Image, layer identifiableLayer, previo
 		return "", errors.Wrapf(err, "exporting layer '%s'", layer.Identifier())
 	}
 	if sha == previousSHA {
-		e.Logger.Debugf("Reusing layer '%s' with SHA %s\n", layer.Identifier(), sha)
+		e.Logger.Infof("Reusing layer '%s'\n", layer.Identifier())
+		e.Logger.Debugf("Layer '%s' SHA: %s\n", layer.Identifier(), sha)
 		return sha, image.ReuseLayer(previousSHA)
 	}
-	e.Logger.Debugf("Exporting layer '%s' with SHA %s\n", layer.Identifier(), sha)
+	e.Logger.Infof("Adding layer '%s'\n", layer.Identifier())
+	e.Logger.Debugf("Layer '%s' SHA: %s\n", layer.Identifier(), sha)
 	return sha, image.AddLayer(tarPath)
 }
 
@@ -204,11 +207,6 @@ func (e *Exporter) saveImage(image imgutil.Image, additionalNames []string) erro
 		}
 	}
 
-	e.Logger.Info("*** Images:")
-	for _, n := range append([]string{image.Name()}, additionalNames...) {
-		e.Logger.Infof("      %s - %s\n", n, getSaveStatus(saveErr, n))
-	}
-
 	id, idErr := image.Identifier()
 	if idErr != nil {
 		if saveErr != nil {
@@ -217,19 +215,18 @@ func (e *Exporter) saveImage(image imgutil.Image, additionalNames []string) erro
 		return idErr
 	}
 
-	e.logReference(id)
-	return saveErr
-}
-
-func (e *Exporter) logReference(identifier imgutil.Identifier) {
-	switch v := identifier.(type) {
-	case local.IDIdentifier:
-		e.Logger.Debugf("\n*** Image ID: %s\n", v.String())
-	case remote.DigestIdentifier:
-		e.Logger.Debugf("\n*** Digest: %s\n", v.Digest.DigestStr())
-	default:
-		e.Logger.Debugf("\n*** Reference: %s\n", v.String())
+	refType, ref := getReference(id)
+	e.Logger.Info("*** Images:")
+	for _, n := range append([]string{image.Name()}, additionalNames...) {
+		if ok, message := getSaveStatus(saveErr, n); !ok {
+			e.Logger.Infof("      %s - %s\n", n, TruncateSha(ref), message)
+		} else {
+			e.Logger.Infof("      %s (%s)\n", n, TruncateSha(ref))
+		}
 	}
+
+	e.Logger.Debugf("\n*** %s: %s\n", refType, ref)
+	return saveErr
 }
 
 type MultiError struct {
@@ -240,15 +237,26 @@ func (me *MultiError) Error() string {
 	return fmt.Sprintf("failed with multiple errors %+v", me.Errors)
 }
 
-func getSaveStatus(err error, imageName string) string {
+func getReference(identifier imgutil.Identifier) (string, string) {
+	switch v := identifier.(type) {
+	case local.IDIdentifier:
+		return "Image ID", v.String()
+	case remote.DigestIdentifier:
+		return "Digest", v.Digest.DigestStr()
+	default:
+		return "Reference", v.String()
+	}
+}
+
+func getSaveStatus(err error, imageName string) (bool, string) {
 	if err != nil {
 		if saveErr, ok := err.(imgutil.SaveError); ok {
 			for _, d := range saveErr.Errors {
 				if d.ImageName == imageName {
-					return d.Cause.Error()
+					return false, d.Cause.Error()
 				}
 			}
 		}
 	}
-	return "succeeded"
+	return true, ""
 }

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -569,9 +569,9 @@ type = "Apache-2.0"
 				h.AssertStringContains(t,
 					outLog.String(),
 					fmt.Sprintf(`*** Images:
-      %s - succeeded
-      %s - succeeded
-      %s - succeeded
+      %s (some-image-i)
+      %s (some-image-i)
+      %s (some-image-i)
 `,
 						fakeAppImage.Name(),
 						additionalNames[0],
@@ -600,9 +600,9 @@ type = "Apache-2.0"
 						outLog.String(),
 						fmt.Sprintf(
 							`*** Images:
-      %s - succeeded
-      %s - succeeded
-      %s - succeeded
+      %s (some-image-i)
+      %s (some-image-i)
+      %s (some-image-i)
       %s - could not parse reference
 
 *** Image ID: some-image-id`,
@@ -972,13 +972,17 @@ func assertAddLayerLog(t *testing.T, stdout bytes.Buffer, name, layerPath string
 	t.Helper()
 	layerSHA := h.ComputeSHA256ForFile(t, layerPath)
 
-	expected := fmt.Sprintf("Exporting layer '%s' with SHA sha256:%s", name, layerSHA)
+	expected := fmt.Sprintf("Adding layer '%s'", name)
+	h.AssertStringContains(t, stdout.String(), expected)
+	expected = fmt.Sprintf("Layer '%s' SHA: sha256:%s", name, layerSHA)
 	h.AssertStringContains(t, stdout.String(), expected)
 }
 
 func assertReuseLayerLog(t *testing.T, stdout bytes.Buffer, name, sha string) {
 	t.Helper()
-	expected := fmt.Sprintf("Reusing layer '%s' with SHA sha256:%s", name, sha)
+	expected := fmt.Sprintf("Reusing layer '%s'", name)
+	h.AssertStringContains(t, stdout.String(), expected)
+	expected = fmt.Sprintf("Layer '%s' SHA: sha256:%s", name, sha)
 	h.AssertStringContains(t, stdout.String(), expected)
 }
 

--- a/utils.go
+++ b/utils.go
@@ -34,6 +34,14 @@ func ReadOrder(path string) (BuildpackOrder, error) {
 	return order.Order, err
 }
 
+func TruncateSha(sha string) string {
+	rawSha := strings.TrimPrefix(sha, "sha256:")
+	if len(sha) > 12 {
+		return rawSha[0:12]
+	}
+	return rawSha
+}
+
 func escapeID(id string) string {
 	return strings.Replace(id, "/", "_", -1)
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -118,4 +118,29 @@ func testUtils(t *testing.T, when spec.G, it spec.S) {
 			}
 		})
 	})
+
+	when(".TruncateSha", func() {
+		it("should truncate the sha", func() {
+			actual := lifecycle.TruncateSha("ed649d0a36b218c476b64d61f85027477ef5742045799f45c8c353562279065a")
+			if s := cmp.Diff(actual, "ed649d0a36b2"); s != "" {
+				t.Fatalf("Unexpected sha:\n%s\n", s)
+			}
+		})
+
+		it("should not truncate the sha with it's short", func() {
+			sha := "not-a-sha"
+			actual := lifecycle.TruncateSha(sha)
+			if s := cmp.Diff(actual, sha); s != "" {
+				t.Fatalf("Unexpected sha:\n%s\n", s)
+			}
+		})
+
+		it("should remove the prefix", func() {
+			sha := "sha256:ed649d0a36b218c476b64d61f85027477ef5742045799f45c8c353562279065a"
+			actual := lifecycle.TruncateSha(sha)
+			if s := cmp.Diff(actual, "ed649d0a36b2"); s != "" {
+				t.Fatalf("Unexpected sha:\n%s\n", s)
+			}
+		})
+	})
 }


### PR DESCRIPTION
Supersedes #173

Here's an example of the info level logging:

```
$ pack build myimage --builder heroku/buildpacks:18 --no-pull
===> DETECTING
[detector] heroku/java 0.14
===> RESTORING
[restorer] Restoring cached layer 'heroku/java:jdk'
[restorer] Restoring cached layer 'heroku/java:maven_m2'
===> ANALYZING
[analyzer] Using cached layer 'heroku/java:jdk'
[analyzer] Using cached layer 'heroku/java:maven_m2'
[analyzer] Writing metadata for uncached layer 'heroku/java:jre'
===> BUILDING
[builder]
...
[builder]
===> EXPORTING
[exporter] Adding layer 'app'
[exporter] Reusing layer 'config'
[exporter] Adding layer 'launcher'
[exporter] Reusing layer 'heroku/java:jre'
[exporter] *** Images:
[exporter]       index.docker.io/library/myimage:latest (a94409e2e599)
===> CACHING
[cacher] Reusing layer 'heroku/java:jdk'
[cacher] Caching layer 'heroku/java:maven_m2'
Successfully built image myimage
```