### PR TITLE
Concise Output

### DIFF
--- a/detector.go
+++ b/detector.go
@@ -2,6 +2,7 @@ package lifecycle
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -147,7 +148,24 @@ func (c *DetectConfig) process(done []Buildpack) ([]Buildpack, []BuildPlanEntry,
 	if err != nil {
 		return nil, nil, err
 	}
-	c.Logger.Infof("Success! (%d)", len(trial))
+
+	if len(done) != len(trial) {
+		c.Logger.Infof("%d of %d buildpacks participating", len(trial), len(done))
+	}
+
+	maxLength := 0
+	for _, t := range trial {
+		l := len(t.ID)
+		if l > maxLength {
+			maxLength = l
+		}
+	}
+
+	f := fmt.Sprintf("%%-%ds %%s", maxLength)
+
+	for _, t := range trial {
+		c.Logger.Infof(f, t.ID, t.Version)
+	}
 
 	var found []Buildpack
 	for _, r := range trial {

--- a/detector_test.go
+++ b/detector_test.go
@@ -119,7 +119,8 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					"pass: A@v1\n"+
 					"pass: B@v1\n"+
 					"Resolving plan... (try #1)\n"+
-					"Success! (2)\n",
+					"A v1\n"+
+					"B v1\n",
 			) {
 				t.Fatalf("Unexpected log:\n%s\n", s)
 			}
@@ -248,7 +249,10 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 						"pass: D@v2\n"+
 						"pass: B@v1\n"+
 						"Resolving plan... (try #1)\n"+
-						"Success! (4)\n",
+						"A v1\n"+
+						"C v2\n"+
+						"D v2\n"+
+						"B v1\n",
 				) {
 					t.Fatalf("Unexpected log:\n%s\n", s)
 				}
@@ -352,7 +356,8 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 						"Resolving plan... (try #1)\n"+
 						"skip: A@v1 requires dep-missing\n"+
 						"skip: C@v1 provides unused dep-missing\n"+
-						"Success! (1)\n",
+						"1 of 3 buildpacks participating\n"+
+						"B v1\n",
 				) {
 					t.Fatalf("Unexpected log:\n%s\n", s)
 				}
@@ -418,7 +423,10 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					"Resolving plan... (try #16)\n"+
 						"skip: D@v1 requires dep9-missing\n"+
 						"skip: D@v1 provides unused dep10-missing\n"+
-						"Success! (3)\n",
+						"3 of 4 buildpacks participating\n"+
+						"A v1\n"+
+						"B v1\n"+
+						"C v1\n",
 				) {
 					t.Fatalf("Unexpected log:\n%s\n", s)
 				}

--- a/go.mod
+++ b/go.mod
@@ -25,3 +25,5 @@ require (
 	google.golang.org/genproto v0.0.0-20190508193815-b515fa19cec8 // indirect
 	google.golang.org/grpc v1.20.1 // indirect
 )
+
+go 1.13


### PR DESCRIPTION
Previously the output of the detect phase was way too verbose printing the id and version of every buildpack and whether it passed or failed.  Given large buildpack groups this was a large block of text that was difficult to visually parse for useful information.

A recent change to the output then simplified it to describe only the number of buildpacks that were participating in the build phase, but removed their id and version.  This version of the output ended up being too terse, removing the genuinely useful information of what buildpacks were manipulating your application.

This change splits the difference between the two previous attempts.  It prints the number of buildpacks participating out of the number of options (implying that the others failed or skipped) and then prints the id and version of each of the participating buildpacks.  The detailed information about the non-participating buildpacks is still useful in some circumstances, and should be added back once logging levels are implemented in the lifecycle. A recommendation would be the current output at Info, and full output at Debug.

Example output:

```plain
===> DETECTING
[detector] 8 of 35 buildpacks participating
[detector] io.pivotal.openjdk                   1.0.7-2-gee0dfc5
[detector] io.pivotal.jvmapplication            1.0.24
[detector] io.pivotal.tomcat                    1.0.33
[detector] io.pivotal.springboot                1.0.29
[detector] io.pivotal.distzip                   1.0.29
[detector] io.pivotal.clientcertificatemapper   1.0.31
[detector] io.pivotal.containersecurityprovider 1.0.27
[detector] io.pivotal.springautoreconfiguration 1.0.33
```