### PR TITLE
Log digest or image id as info level instead of debug

### DIFF
--- a/exporter_test.go
+++ b/exporter_test.go
@@ -568,10 +568,10 @@ type = "Apache-2.0"
 
 				h.AssertStringContains(t,
 					outLog.String(),
-					fmt.Sprintf(`*** Images:
-      %s (some-image-i)
-      %s (some-image-i)
-      %s (some-image-i)
+					fmt.Sprintf(`*** Images (some-image-i):
+      %s
+      %s
+      %s
 `,
 						fakeAppImage.Name(),
 						additionalNames[0],
@@ -599,10 +599,10 @@ type = "Apache-2.0"
 					h.AssertStringContains(t,
 						outLog.String(),
 						fmt.Sprintf(
-							`*** Images:
-      %s (some-image-i)
-      %s (some-image-i)
-      %s (some-image-i)
+							`*** Images (some-image-i):
+      %s
+      %s
+      %s
       %s - could not parse reference
 
 *** Image ID: some-image-id`,

--- a/save.go
+++ b/save.go
@@ -38,7 +38,7 @@ func saveImage(image imgutil.Image, additionalNames []string, logger logging.Log
 		}
 	}
 
-	logger.Debugf("\n*** %s: %s\n", refType, ref)
+	logger.Infof("\n*** %s: %s\n", refType, ref)
 	return saveErr
 }
 

--- a/save.go
+++ b/save.go
@@ -29,12 +29,12 @@ func saveImage(image imgutil.Image, additionalNames []string, logger logging.Log
 	}
 
 	refType, ref, shortRef := getReference(id)
-	logger.Info("*** Images:")
+	logger.Infof("*** Images (%s):\n", shortRef)
 	for _, n := range append([]string{image.Name()}, additionalNames...) {
 		if ok, message := getSaveStatus(saveErr, n); !ok {
 			logger.Infof("      %s - %s\n", n, message)
 		} else {
-			logger.Infof("      %s (%s)\n", n, shortRef)
+			logger.Infof("      %s\n", n)
 		}
 	}
 

--- a/save.go
+++ b/save.go
@@ -28,17 +28,17 @@ func saveImage(image imgutil.Image, additionalNames []string, logger logging.Log
 		return idErr
 	}
 
-	refType, ref := getReference(id)
+	refType, ref, shortRef := getReference(id)
 	logger.Info("*** Images:")
 	for _, n := range append([]string{image.Name()}, additionalNames...) {
 		if ok, message := getSaveStatus(saveErr, n); !ok {
 			logger.Infof("      %s - %s\n", n, message)
 		} else {
-			logger.Infof("      %s (%s)\n", n, TruncateSha(ref))
+			logger.Infof("      %s (%s)\n", n, shortRef)
 		}
 	}
 
-	logger.Infof("\n*** %s: %s\n", refType, ref)
+	logger.Debugf("\n*** %s: %s\n", refType, ref)
 	return saveErr
 }
 
@@ -50,14 +50,14 @@ func (me *MultiError) Error() string {
 	return fmt.Sprintf("failed with multiple errors %+v", me.Errors)
 }
 
-func getReference(identifier imgutil.Identifier) (string, string) {
+func getReference(identifier imgutil.Identifier) (string, string, string) {
 	switch v := identifier.(type) {
 	case local.IDIdentifier:
-		return "Image ID", v.String()
+		return "Image ID", v.String(), TruncateSha(v.String())
 	case remote.DigestIdentifier:
-		return "Digest", v.Digest.DigestStr()
+		return "Digest", v.Digest.DigestStr(), v.Digest.DigestStr()
 	default:
-		return "Reference", v.String()
+		return "Reference", v.String(), v.String()
 	}
 }
 


### PR DESCRIPTION
```
[builder]
===> EXPORTING
[exporter] Adding layer 'app'
[exporter] Reusing layer 'config'
[exporter] Adding layer 'launcher'
[exporter] Reusing layer 'heroku/java:jre'
[exporter] *** Images:
[exporter]       index.docker.io/library/myimage:latest (ae41bec06d78)
[exporter]
[exporter] *** Image ID: ae41bec06d78175a2bfadbf0d39dd0e5ba9dcf046a5d8c2d76b8205eb419eac1
===> CACHING
[cacher] Reusing layer 'heroku/java:jdk'
[cacher] Caching layer 'heroku/java:maven_m2'
Successfully built image myimage
```