### PR TITLE
Use version of imgutil that zeros history on remote save

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/buildpack/lifecycle
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/apex/log v1.1.1
-	github.com/buildpack/imgutil v0.0.0-20190726132853-1f31ed20483a
+	github.com/buildpack/imgutil v0.0.0-20191010153712-78959154ded1
 	github.com/docker/docker v0.7.3-0.20190307005417-54dddadc7d5d
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy
 github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
 github.com/aws/aws-sdk-go v1.20.6/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
-github.com/buildpack/imgutil v0.0.0-20190726132853-1f31ed20483a h1:N9h8e7nYvJKpfQdEGU3RK/xSLXIuhPQURH0g3KIGgM0=
-github.com/buildpack/imgutil v0.0.0-20190726132853-1f31ed20483a/go.mod h1:X0yFLGZtSyTXsEJq9NaPP9Rdnaq+3wouZ7xaTgw1680=
+github.com/buildpack/imgutil v0.0.0-20191010153712-78959154ded1 h1:8569yKDg8c4Qo/dMeBaUaWDn62hmrEBgqVMYdeDZysk=
+github.com/buildpack/imgutil v0.0.0-20191010153712-78959154ded1/go.mod h1:xl28ycwHsITb5aDb5ExzC7ud2qoUcKy+cMhbr2pKMrM=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -157,8 +157,6 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
-golang.org/x/tools v0.0.0-20190624190245-7f2218787638 h1:uIfBkD8gLczr4XDgYpt/qJYds2YJwZRNw4zs7wSnNhk=
-golang.org/x/tools v0.0.0-20190624190245-7f2218787638/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190808195139-e713427fea3f h1:lSQQYboXWc71s9tnZRRBiMcc9Uc1BPWj3Bzvdk8UQ0Y=
 golang.org/x/tools v0.0.0-20190808195139-e713427fea3f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/vendor/github.com/buildpack/imgutil/.travis.yml
+++ b/vendor/github.com/buildpack/imgutil/.travis.yml
@@ -1,17 +1,18 @@
-sudo: required
-services:
-- docker
-install:
-- set -e
+language: go
+go: 1.12.x
+dist: trusty
+
+env:
+  global:
+    - GO111MODULE=on
+
 jobs:
   include:
-  - stage: unit test
-    language: go
-    go:
-    - 1.11.x
-    env:
-    - GO111MODULE=on
-    go_import_path: github.com/buildpack/lifecycle
-    script: |
-      test -z "$(bin/format | tee >(cat >&2))"
-      go test -v -parallel=1 -p=1 -count=1 ./...
+    - os: linux
+      script: 
+        - docker info
+        - make
+
+branches:
+  only:
+    - master

--- a/vendor/github.com/buildpack/imgutil/README.md
+++ b/vendor/github.com/buildpack/imgutil/README.md
@@ -9,7 +9,7 @@ Helpful utilities for working with images
 To format:
 
 ```bash
-$ make format imports
+$ make format
 ```
 
 To run tests:

--- a/vendor/github.com/buildpack/imgutil/go.mod
+++ b/vendor/github.com/buildpack/imgutil/go.mod
@@ -22,7 +22,6 @@ require (
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20190416152802-12500544f89f // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
-	golang.org/x/tools v0.0.0-20190624190245-7f2218787638
 	google.golang.org/grpc v1.20.0 // indirect
 	gotest.tools v2.2.0+incompatible // indirect
 )

--- a/vendor/github.com/buildpack/imgutil/go.sum
+++ b/vendor/github.com/buildpack/imgutil/go.sum
@@ -79,8 +79,6 @@ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZe
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
-golang.org/x/tools v0.0.0-20190624190245-7f2218787638 h1:uIfBkD8gLczr4XDgYpt/qJYds2YJwZRNw4zs7wSnNhk=
-golang.org/x/tools v0.0.0-20190624190245-7f2218787638/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0NQvRW8DG4Yk3Q6T9cu9RcFQDu1tc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/vendor/github.com/buildpack/imgutil/remote/remote.go
+++ b/vendor/github.com/buildpack/imgutil/remote/remote.go
@@ -343,6 +343,22 @@ func (i *Image) Save(additionalNames ...string) error {
 		return errors.Wrap(err, "set creation time")
 	}
 
+	cfg, err := i.image.ConfigFile()
+	if err != nil {
+		return errors.Wrap(err, "get image config")
+	}
+
+	layers, err := i.image.Layers()
+	if err != nil {
+		return errors.Wrap(err, "get image layers")
+	}
+
+	cfg.History = make([]v1.History, len(layers))
+	i.image, err = mutate.ConfigFile(i.image, cfg)
+	if err != nil {
+		return errors.Wrap(err, "zeroing history")
+	}
+
 	var diagnostics []imgutil.SaveDiagnostic
 	for _, n := range allNames {
 		if err := i.doSave(n); err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,7 +4,7 @@ github.com/BurntSushi/toml
 github.com/Microsoft/go-winio
 # github.com/apex/log v1.1.1
 github.com/apex/log
-# github.com/buildpack/imgutil v0.0.0-20190726132853-1f31ed20483a
+# github.com/buildpack/imgutil v0.0.0-20191010153712-78959154ded1
 github.com/buildpack/imgutil
 github.com/buildpack/imgutil/local
 github.com/buildpack/imgutil/remote


### PR DESCRIPTION
- This allow rebases to work on images on artifactory. Artifactory fails rebase as as it run into problems with the history on the img config.

Signed-off-by: Ashwin Venkatesh <avenkatesh@pivotal.io>
Signed-off-by: Danny Joyce <djoyce@pivotal.io>

This issue is similar to the one described here: GoogleContainerTools/jib#534