### PR TITLE
Build all binaries at once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.12.x
+- 1.13.x
 script:
 - make test
 branches:

--- a/Makefile
+++ b/Makefile
@@ -24,22 +24,14 @@ all: test build package
 
 build:
 	@echo "> Building lifecycle..."
-	mkdir -p ./out/$(ARCHIVE_NAME)
-	$(GOENV) $(GOBUILD) -o ./out/lifecycle/detector -a ./cmd/detector
-	$(GOENV) $(GOBUILD) -o ./out/lifecycle/restorer -a ./cmd/restorer
-	$(GOENV) $(GOBUILD) -o ./out/lifecycle/analyzer -a ./cmd/analyzer
-	$(GOENV) $(GOBUILD) -o ./out/lifecycle/builder -a ./cmd/builder
-	$(GOENV) $(GOBUILD) -o ./out/lifecycle/exporter -a ./cmd/exporter
-	$(GOENV) $(GOBUILD) -o ./out/lifecycle/cacher -a ./cmd/cacher
-	$(GOENV) $(GOBUILD) -o ./out/lifecycle/launcher -a ./cmd/launcher
-	$(GOENV) $(GOBUILD) -o ./out/lifecycle/rebaser -a ./cmd/rebaser
+	mkdir -p ./out/lifecycle
+	$(GOENV) $(GOBUILD) -o ./out/lifecycle -a ./cmd/...
 
 descriptor: export LIFECYCLE_DESCRIPTOR:=$(LIFECYCLE_DESCRIPTOR)
 descriptor:
 	@echo "> Writing descriptor file..."
 	mkdir -p ./out
 	echo "$${LIFECYCLE_DESCRIPTOR}" > ./out/lifecycle.toml
-
 
 install-goimports:
 	@echo "> Installing goimports..."


### PR DESCRIPTION
Use a go 1.13 feature to build all lifecycle binaries with a single command.
Leads a simpler makefile and also usually faster builds.