### PR TITLE
Clean up usage of assertNil in tests

### DIFF
--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -530,7 +530,7 @@ func testAnalyzer(t *testing.T, when spec.G, it spec.S) {
 			it("clears the cached launch layers", func() {
 				h.RecursiveCopy(t, filepath.Join("testdata", "analyzer", "cached-layers"), layerDir)
 				_, err := analyzer.Analyze(notFoundImage)
-				assertNil(t, err)
+				h.AssertNil(t, err)
 
 				if _, err := ioutil.ReadDir(filepath.Join(layerDir, "no.metadata.buildpack", "launchlayer")); !os.IsNotExist(err) {
 					t.Fatalf("Found stale launchlayer cache, it should not exist")
@@ -561,7 +561,7 @@ func testAnalyzer(t *testing.T, when spec.G, it spec.S) {
 				h.RecursiveCopy(t, filepath.Join("testdata", "analyzer", "cached-layers"), layerDir)
 
 				_, err := analyzer.Analyze(image)
-				assertNil(t, err)
+				h.AssertNil(t, err)
 
 				if _, err := ioutil.ReadDir(filepath.Join(layerDir, "no.metadata.buildpack", "launchlayer")); !os.IsNotExist(err) {
 					t.Fatalf("Found stale launchlayer cache, it should not exist")
@@ -584,7 +584,7 @@ func testAnalyzer(t *testing.T, when spec.G, it spec.S) {
 				h.RecursiveCopy(t, filepath.Join("testdata", "analyzer", "cached-layers"), layerDir)
 
 				_, err := analyzer.Analyze(image)
-				assertNil(t, err)
+				h.AssertNil(t, err)
 
 				if _, err := ioutil.ReadDir(filepath.Join(layerDir, "no.metadata.buildpack", "launchlayer")); !os.IsNotExist(err) {
 					t.Fatalf("Found stale launchlayer cache, it should not exist")
@@ -598,11 +598,4 @@ func testAnalyzer(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 	})
-}
-
-func assertNil(t *testing.T, actual interface{}) {
-	t.Helper()
-	if actual != nil {
-		t.Fatalf("Expected nil: %s", actual)
-	}
 }

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -998,7 +998,7 @@ func assertTarFileContents(t *testing.T, tarfile, path, expected string) {
 func tarFileContext(t *testing.T, tarfile, path string) (exist bool, contents string) {
 	t.Helper()
 	r, err := os.Open(tarfile)
-	assertNil(t, err)
+	h.AssertNil(t, err)
 	defer r.Close()
 
 	tr := tar.NewReader(r)
@@ -1007,11 +1007,11 @@ func tarFileContext(t *testing.T, tarfile, path string) (exist bool, contents st
 		if err == io.EOF {
 			break
 		}
-		assertNil(t, err)
+		h.AssertNil(t, err)
 
 		if header.Name == path {
 			buf, err := ioutil.ReadAll(tr)
-			assertNil(t, err)
+			h.AssertNil(t, err)
 			return true, string(buf)
 		}
 	}
@@ -1022,7 +1022,7 @@ func assertTarFileOwner(t *testing.T, tarfile, path string, expectedUID, expecte
 	t.Helper()
 	var foundPath bool
 	r, err := os.Open(tarfile)
-	assertNil(t, err)
+	h.AssertNil(t, err)
 	defer r.Close()
 
 	tr := tar.NewReader(r)
@@ -1031,7 +1031,7 @@ func assertTarFileOwner(t *testing.T, tarfile, path string, expectedUID, expecte
 		if err == io.EOF {
 			break
 		}
-		assertNil(t, err)
+		h.AssertNil(t, err)
 
 		if header.Name == path {
 			foundPath = true


### PR DESCRIPTION
exporter_test.go referred to non-existent 'assertNil'
analyzer_test.go re-implemented a function from testhelpers