### PR TITLE
Fix permissions when untarring files with umask

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -147,6 +147,10 @@ func Untar(r io.Reader, dest string) error {
 			if err := writeFile(tr, path, hdr.FileInfo().Mode()); err != nil {
 				return err
 			}
+			// Update permissions in case umask was applied.
+			if err := os.Chmod(path, hdr.FileInfo().Mode()); err != nil {
+				return err
+			}
 		case tar.TypeSymlink:
 			if err := os.Symlink(hdr.Linkname, path); err != nil {
 				return err

--- a/archive/tar_test.go
+++ b/archive/tar_test.go
@@ -86,6 +86,8 @@ func testTar(t *testing.T, when spec.G, it spec.S) {
 
 		it("doesn't alter permissions of existing folders", func() {
 			h.AssertNil(t, os.Mkdir(filepath.Join(tmpDir, "root"), 0744))
+			// Update permissions in case umask was applied.
+			h.AssertNil(t, os.Chmod(filepath.Join(tmpDir, "root"), 0744))
 			h.AssertNil(t, archive.Untar(file, tmpDir))
 			fileInfo, err := os.Stat(filepath.Join(tmpDir, "root"))
 			h.AssertNil(t, err)


### PR DESCRIPTION
Umask can change the permissions of the file being written leading to the created file having different permissions than it should according to the tar archive.

For example, with umask 027, two tests fail:

```
Suite: tar
Total: 9 | Focused: 0 | Pending: 0
x.x......
Passed: 7 | Failed: 2 | Skipped: 0

--- FAIL: TestTar (0.00s)
    --- FAIL: TestTar/tar (0.00s)
        --- FAIL: TestTar/tar/#ReadTarArchive/extracts_a_tar_file (0.00s)
            tar_test.go:77:   os.FileMode(
                -       s"-rw-r-----",
                +       s"-rw-r--r--",
                  )

        --- FAIL: TestTar/tar/#ReadTarArchive/doesn't_alter_permissions_of_existing_folders (0.00s)
            tar_test.go:92:   os.FileMode(
                -       s"drwxr-----",
                +       s"drwxr--r--",
                  )

FAIL
FAIL    command-line-arguments  0.073s
```