### PR TITLE
Fix error checking when writing archives for cached layers

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -20,7 +20,7 @@ func WriteTarFile(sourceDir, dest string, uid, gid int) (string, error) {
 	defer f.Close()
 	w := io.MultiWriter(hasher, f)
 
-	if WriteTarArchive(w, sourceDir, uid, gid) != nil {
+	if err := WriteTarArchive(w, sourceDir, uid, gid); err != nil {
 		return "", err
 	}
 	sha := hex.EncodeToString(hasher.Sum(make([]byte, 0, hasher.Size())))


### PR DESCRIPTION
When the cacher encounters an error writing the tar archive, you get an error like this:

```
Caching layer 'io.greenhouse.some-buildpack:some-layer'
Layer 'io.greenhouse.some-buildpack:some-layer' SHA: sha256:8e4f67fe86cb12dc6233c86b08434ee7db1e03e722e46fa3c80a9041f63cb437
Reusing layer 'io.greenhouse.some-buildpack:other-layer'
Layer 'io.greenhouse.some-buildpack:other-layer' SHA:
ERROR: failed to cache: previous image did not have layer with sha ''
```

With  this change, the error properly bubbles up:

```
Caching layer 'io.greenhouse.some-buildpack:some-layer'
Layer 'io.greenhouse.some-buildpack:some-layer' SHA: sha256:8e4f67fe86cb12dc6233c86b08434ee7db1e03e722e46fa3c80a9041f63cb437
ERROR: failed to cache: caching layer 'io.greenhouse.some-buildpack:other-layer': open /layers/io.greenhouse.some-buildpack/other-layer/some/file/owned/by/root: permission denied
```