### PR TITLE
Return err from WriteTarArchive

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -20,7 +20,7 @@ func WriteTarFile(sourceDir, dest string, uid, gid int) (string, error) {
 	defer f.Close()
 	w := io.MultiWriter(hasher, f)
 
-	if WriteTarArchive(w, sourceDir, uid, gid) != nil {
+	if err := WriteTarArchive(w, sourceDir, uid, gid); err != nil {
 		return "", err
 	}
 	sha := hex.EncodeToString(hasher.Sum(make([]byte, 0, hasher.Size())))


### PR DESCRIPTION
Today, when `WriteTarArchive` returns an error it gets dropped and the exporter continues processing the tar as if the sha is an empty string. 

This leads to opaque export errors:
```
ERROR: failed to export: previous image did not have layer with sha ''
```